### PR TITLE
Output components as svgstore (SVG Sprites)

### DIFF
--- a/packages/output-components-as-svgstore/README.md
+++ b/packages/output-components-as-svgstore/README.md
@@ -1,0 +1,34 @@
+# @figma-export/output-components-as-svgstore
+
+> Outputter for [@figma-export](https://github.com/marcomontalbano/figma-export) that exports components in svg file (`SVG Sprites`).
+
+With this outputter you can export all components as `<symbol>` inside a `.svg` file named with the page name.
+
+This is a sample of the output:
+
+```sh
+$ tree output/
+# output/
+# ├── icons.svg
+# └── monochrome.svg
+```
+
+Probably you already know what <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/css-sprites/">CSS Sprites</a> are, basically you can combine multiple images into a single image file and use it on a website.
+
+**SVG Sprites** are very similar, but use svg instead of png.
+
+You can read more on <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/svg-sprites-use-better-icon-fonts/">Icon System with SVG Sprites</a> article where you can find how to use them.
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @figma-export/output-components-as-svgstore
+```
+
+or using yarn:
+
+```sh
+yarn add @figma-export/output-components-as-svgstore --dev
+```

--- a/packages/output-components-as-svgstore/index.js
+++ b/packages/output-components-as-svgstore/index.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const makeDir = require('make-dir');
+const svgstore = require('svgstore');
+
+module.exports = ({
+    output,
+    iconPrefix = '',
+    options = {},
+}) => {
+    makeDir.sync(output);
+    return async (pages) => {
+        pages.forEach(({ name: pageName, components }) => {
+            const sprites = svgstore(options);
+
+            components.forEach(({ name: componentName, svg }) => {
+                sprites.add(`${iconPrefix}${pageName}-${componentName}`, svg);
+            });
+
+            const filePath = path.resolve(output, `${pageName}.svg`);
+            fs.writeFileSync(filePath, sprites);
+        });
+    };
+};

--- a/packages/output-components-as-svgstore/index.test.js
+++ b/packages/output-components-as-svgstore/index.test.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+const { expect } = chai;
+
+const fs = require('fs');
+
+const figmaDocument = require('../core/lib/_config.test');
+const figma = require('../core/lib/figma');
+
+const outputter = require('./index');
+
+describe('outputter as svgstore', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should create an svg with the page name as filename', async () => {
+        const writeFileSync = sinon.stub(fs, 'writeFileSync');
+        const pages = figma.getPages({ children: [figmaDocument.page1] });
+
+        await outputter({
+            output: 'output',
+        })(pages);
+
+        expect(writeFileSync).to.be.calledOnce;
+        expect(writeFileSync).to.be.calledWithMatch('output/page1.svg');
+    });
+});

--- a/packages/output-components-as-svgstore/package-lock.json
+++ b/packages/output-components-as-svgstore/package-lock.json
@@ -1,0 +1,229 @@
+{
+    "name": "@figma-export/output-components-as-svgstore",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+        },
+        "cheerio": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+            "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+            "requires": {
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash.assignin": "^4.0.9",
+                "lodash.bind": "^4.1.4",
+                "lodash.defaults": "^4.0.1",
+                "lodash.filter": "^4.4.0",
+                "lodash.flatten": "^4.2.0",
+                "lodash.foreach": "^4.3.0",
+                "lodash.map": "^4.4.0",
+                "lodash.merge": "^4.4.0",
+                "lodash.pick": "^4.2.1",
+                "lodash.reduce": "^4.4.0",
+                "lodash.reject": "^4.4.0",
+                "lodash.some": "^4.4.0"
+            }
+        },
+        "css-select": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "requires": {
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
+                "domutils": "1.5.1",
+                "nth-check": "~1.0.1"
+            }
+        },
+        "css-what": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+            "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+        },
+        "dom-serializer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+            "requires": {
+                "domelementtype": "^1.3.0",
+                "entities": "^1.1.1"
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
+        "domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        },
+        "htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "requires": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "lodash.assignin": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+            "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+        },
+        "lodash.bind": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+            "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+        },
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+        },
+        "lodash.filter": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+            "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+        },
+        "lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+        },
+        "lodash.foreach": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+            "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+        },
+        "lodash.map": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+            "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+        },
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        },
+        "lodash.pick": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+            "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+        },
+        "lodash.reduce": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+            "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+        },
+        "lodash.reject": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+            "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+        },
+        "lodash.some": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+            "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+        },
+        "make-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+            "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+            "requires": {
+                "semver": "^6.0.0"
+            }
+        },
+        "nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "requires": {
+                "boolbase": "~1.0.0"
+            }
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "readable-stream": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+            "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+            "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "svgstore": {
+            "version": "3.0.0-2",
+            "resolved": "https://registry.npmjs.org/svgstore/-/svgstore-3.0.0-2.tgz",
+            "integrity": "sha512-qiR9MvGgCWLuuspa9wFkafE1BrwrtsoFwhsWHt6zFK7vq3TcYKPCKFOVDBa0rAflF7/GI3SFIE+h38l8vFCFgQ==",
+            "requires": {
+                "cheerio": "^0.22.0",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        }
+    }
+}

--- a/packages/output-components-as-svgstore/package.json
+++ b/packages/output-components-as-svgstore/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@figma-export/output-components-as-svgstore",
+    "version": "1.0.0",
+    "description": "Outputter for @figma-export that exports components in svg file ( SVG Sprites )",
+    "main": "index.js",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/marcomontalbano/figma-exporter.git",
+        "directory": "packages/output-components-as-svgstore"
+    },
+    "author": "Marco Montalbano <me@marcomontalbano.com>",
+    "license": "MIT",
+    "publishConfig": {
+        "access": "public"
+    },
+    "dependencies": {
+        "make-dir": "~3.0.0",
+        "svgstore": "~3.0.0-2"
+    }
+}

--- a/packages/website/.babelrc
+++ b/packages/website/.babelrc
@@ -1,0 +1,10 @@
+{
+    "plugins": [
+        ["@babel/plugin-transform-react-jsx", { "pragma":"h", "jsxPragma": "h" }],
+        ["babel-plugin-jsx-pragmatic", {
+            "module": "preact",
+            "import": "h",
+            "export": "h"
+        }]
+    ]
+}

--- a/packages/website/.figmaexportrc.js
+++ b/packages/website/.figmaexportrc.js
@@ -25,16 +25,18 @@ module.exports = {
                     output: './output/es6-dataurl',
                     useDataUrl: true,
                 }),
-                // require('../output-components-as-svgstore')({
-                //     output: './output/svgstore',
-                // }),
-                // require('../output-components-as-svgstore')({
-                //     output: './output/svgstore-monochrome',
-                //     options: {
-                //         prefix: 'monochrome-',
-                //         cleanSymbols: ['fill']
-                //     }
-                // }),
+
+                require('../output-components-as-svgstore')({
+                    output: './output/svgstore',
+                }),
+
+                require('../output-components-as-svgstore')({
+                    output: './output/svgstore-monochrome',
+                    iconPrefix: 'unfilled-',
+                    options: {
+                        cleanSymbols: ['fill']
+                    }
+                }),
             ]
         }]
     ]

--- a/packages/website/index.scss
+++ b/packages/website/index.scss
@@ -12,6 +12,14 @@ $color-link-hover: #1976D2;
     }
 }
 
+.text-center {
+    text-align: center;
+}
+
+.nowrap {
+    white-space: nowrap;
+}
+
 body {
     margin: 0;
     font-family: Lato;
@@ -181,11 +189,15 @@ pre[class*=language-] {
     padding: 0 15px;
 }
 
+.section-block {
+    margin: 60px 0;
+}
+
 .code-block {
     display: flex;
     justify-content: space-around;
     flex-direction: column;
-    margin: 60px 0 15px 0;
+    margin: 15px 0;
 
     @include for-desktop-up {
         align-items: center;

--- a/packages/website/package-lock.json
+++ b/packages/website/package-lock.json
@@ -14,18 +14,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
-			"integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.4.tgz",
+			"integrity": "sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.7.2",
-				"@babel/helpers": "^7.7.0",
-				"@babel/parser": "^7.7.2",
-				"@babel/template": "^7.7.0",
-				"@babel/traverse": "^7.7.2",
-				"@babel/types": "^7.7.2",
+				"@babel/generator": "^7.7.4",
+				"@babel/helpers": "^7.7.4",
+				"@babel/parser": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -35,6 +35,92 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+					"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
+					"integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"json5": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
@@ -92,13 +178,26 @@
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.0.tgz",
-			"integrity": "sha512-LSln3cexwInTMYYoFeVLKnYPPMfWNJ8PubTBs3hkh7wCu9iBaqq1OOyW+xGmEdLxT1nhsl+9SJ+h2oUDYz0l2A==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.4.tgz",
+			"integrity": "sha512-kvbfHJNN9dg4rkEM4xn1s8d1/h6TYNvajy9L1wx4qLn9HFg0IkTsQi4rfBe92nxrPUFcMsHoMV+8rU7MJb3fCA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.7.0",
+				"@babel/types": "^7.7.4",
 				"esutils": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-call-delegate": {
@@ -285,14 +384,108 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
-			"integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
+			"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+					"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
+					"integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/highlight": {
@@ -410,9 +603,9 @@
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
-			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz",
+			"integrity": "sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -687,14 +880,14 @@
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.0.tgz",
-			"integrity": "sha512-mXhBtyVB1Ujfy+0L6934jeJcSXj/VCg6whZzEcgiiZHNS0PGC7vUCsZDQCxxztkpIdF+dY1fUMcjAgEOC3ZOMQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.4.tgz",
+			"integrity": "sha512-LixU4BS95ZTEAZdPaIuyg/k8FiiqN9laQ0dMHB4MlpydHY53uQdWCUrwjLr5o6ilS6fAgZey4Q14XBjl5tL6xw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.7.0",
+				"@babel/helper-builder-react-jsx": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.2.0"
+				"@babel/plugin-syntax-jsx": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
@@ -1628,6 +1821,21 @@
 			"requires": {
 				"object.assign": "^4.1.0"
 			}
+		},
+		"babel-plugin-jsx-pragmatic": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-1.0.2.tgz",
+			"integrity": "sha1-QeK+uGQiNfNLKnqxLKOeByAbjlk=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-syntax-jsx": "^6.0.0"
+			}
+		},
+		"babel-plugin-syntax-jsx": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-runtime": {
 			"version": "6.26.0",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -13,7 +13,10 @@
         "build": "parcel build index.html"
     },
     "devDependencies": {
+        "@babel/core": "~7.7.4",
+        "@babel/plugin-transform-react-jsx": "~7.7.4",
         "@figma-export/cli": "^1.0.0",
+        "babel-plugin-jsx-pragmatic": "~1.0.2",
         "parcel-bundler": "~1.12.4",
         "sass": "~1.23.7"
     },

--- a/packages/website/src/CodeBlock.js
+++ b/packages/website/src/CodeBlock.js
@@ -1,12 +1,10 @@
-import { h } from 'preact';
-
 const CodeBlock = ({
     title,
     description,
     code,
     children
 }) => (
-    <div className="container code-block">
+    <div className="code-block">
         <div class="code-block--text">
             <h3>{title}</h3>
             <p>{description}</p>

--- a/packages/website/src/GitHubLink.js
+++ b/packages/website/src/GitHubLink.js
@@ -1,6 +1,5 @@
-/* eslint-disable import/no-unresolved */
-import { h } from 'preact';
 
+// eslint-disable-next-line import/no-unresolved
 import { iconMarkGithub } from '../output/es6-dataurl-octicons/Octicons';
 
 const GitHubLink = () => (

--- a/packages/website/src/Hero.js
+++ b/packages/website/src/Hero.js
@@ -1,7 +1,7 @@
-/* eslint-disable import/no-unresolved */
-import { h } from 'preact';
-
+// eslint-disable-next-line import/no-unresolved
 import * as Octicons from '../output/es6-dataurl-octicons/Octicons';
+
+// eslint-disable-next-line import/no-unresolved
 import { figmaArrow } from '../output/es6-dataurl/icons';
 
 import figmaImage from '../images/figma-octicons.png';
@@ -10,7 +10,6 @@ const Hero = () => (
     <div className="octicons">
         <div className="figma-screen">
             <img src={figmaImage} />
-            {/* <div className="copyright"><a target="_blank" rel="noopener noreferrer" href="https://github.com/primer/octicons">A scalable set of icons handcrafted with <span>❤️</span> by GitHub</a></div> */}
         </div>
         <div className="figma-export">
             <div className="figma-gradient text title">

--- a/packages/website/src/index.js
+++ b/packages/website/src/index.js
@@ -1,8 +1,9 @@
-import { h, render, Fragment } from 'preact';
+import { render, Fragment } from 'preact';
+
 import SvgOcticons from './Hero';
-import SvgAsES6ComponentDataUrl from './SvgAsES6ComponentDataUrl';
-import SvgAsES6ComponentBase64 from './SvgAsES6ComponentBase64';
 import GitHubLink from './GitHubLink';
+import ComponentsAsES6 from './output-components/ComponentsAsES6';
+import ComponentsAsSvgstore from './output-components/ComponentsAsSvgstore';
 
 const App = () => (
     <Fragment>
@@ -18,8 +19,8 @@ const App = () => (
             <SvgOcticons />
         </div>
         <GitHubLink />
-        <SvgAsES6ComponentDataUrl />
-        <SvgAsES6ComponentBase64 />
+        <ComponentsAsES6 />
+        <ComponentsAsSvgstore />
     </Fragment>
 );
 

--- a/packages/website/src/output-components/ComponentsAsES6.js
+++ b/packages/website/src/output-components/ComponentsAsES6.js
@@ -1,0 +1,18 @@
+import ComponentsAsES6DataUrl from './ComponentsAsES6_dataUrl';
+import ComponentsAsES6Base64 from './ComponentsAsES6_base64';
+
+const ComponentsAsES6 = () => (
+    <div class="section-block container text-center">
+        <h2><code class="figma-gradient with-opacity-10">SVG into .js</code></h2>
+        <p>
+            Exporting SVG into JS is a good solution.
+            You will have multiple exported variables that you can easily import in your project.
+            Another benefit is being able to use tree shaking
+            to load only icons that you really need.
+        </p>
+        <ComponentsAsES6DataUrl />
+        <ComponentsAsES6Base64 />
+    </div>
+);
+
+export default ComponentsAsES6;

--- a/packages/website/src/output-components/ComponentsAsES6_base64.js
+++ b/packages/website/src/output-components/ComponentsAsES6_base64.js
@@ -1,9 +1,12 @@
-/* eslint-disable import/no-unresolved */
-import { h, Fragment } from 'preact';
+import { Fragment } from 'preact';
 
-import CodeBlock from './CodeBlock';
-import * as figmaMonochrome from '../output/es6-base64/monochrome';
-import { figmaExport, figmaLogo } from '../output/es6-base64/icons';
+import CodeBlock from '../CodeBlock';
+
+// eslint-disable-next-line import/no-unresolved
+import * as figmaMonochrome from '../../output/es6-base64/monochrome';
+
+// eslint-disable-next-line import/no-unresolved
+import { figmaExport, figmaLogo } from '../../output/es6-base64/icons';
 
 const props = {
     title: (
@@ -11,7 +14,13 @@ const props = {
             Export your icons as <code class="figma-gradient with-opacity-10">Base 64</code>
         </Fragment>
     ),
-    description: 'The .js file contains all components with Base 64 encoding. If you want to use it into your images you need to prepend the Data URL "data:image/svg+xml;base64,"',
+    description: (
+        <Fragment>
+            The .js file contains all components with Base 64 encoding.
+            If you want to use it into your images you need to prepend the
+            Data URL <code>data:image/svg+xml;base64,</code>
+        </Fragment>
+    ),
     code: `module.exports = {
         commands: [
             ['components', {

--- a/packages/website/src/output-components/ComponentsAsES6_dataUrl.js
+++ b/packages/website/src/output-components/ComponentsAsES6_dataUrl.js
@@ -1,9 +1,12 @@
-/* eslint-disable import/no-unresolved */
-import { h, Fragment } from 'preact';
+import { Fragment } from 'preact';
 
-import CodeBlock from './CodeBlock';
-import * as figmaMonochrome from '../output/es6-dataurl/monochrome';
-import { figmaExport, figmaLogo } from '../output/es6-dataurl/icons';
+import CodeBlock from '../CodeBlock';
+
+// eslint-disable-next-line import/no-unresolved
+import * as figmaMonochrome from '../../output/es6-dataurl/monochrome';
+
+// eslint-disable-next-line import/no-unresolved
+import { figmaExport, figmaLogo } from '../../output/es6-dataurl/icons';
 
 const props = {
     title: (

--- a/packages/website/src/output-components/ComponentsAsSvgstore.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore.js
@@ -1,0 +1,16 @@
+import ComponentsAsSvgstoreDefault from './ComponentsAsSvgstore_default';
+import ComponentsAsSvgstoreMonochrome from './ComponentsAsSvgstore_monochrome';
+
+const ComponentsAsSvgstore = () => (
+    <div class="section-block container text-center">
+        <h2><code class="figma-gradient with-opacity-10">SVG Sprites</code></h2>
+        <p>
+            Probably you already know what <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/css-sprites/">CSS Sprites</a> are, basically you can combine multiple images into a single image file and use it on a website.
+            SVG Sprites are very similar, but you will use .svg instead of .png. Discover more on this article "<a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/svg-sprites-use-better-icon-fonts/">Icon System with SVG Sprites</a>" where you will also find how to use this technique.
+        </p>
+        <ComponentsAsSvgstoreDefault />
+        <ComponentsAsSvgstoreMonochrome />
+    </div>
+);
+
+export default ComponentsAsSvgstore;

--- a/packages/website/src/output-components/ComponentsAsSvgstore_default.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore_default.js
@@ -1,0 +1,54 @@
+/* eslint-disable react/no-danger */
+import { Fragment } from 'preact';
+
+import CodeBlock from '../CodeBlock';
+
+const fs = require('fs');
+
+const figmaMonochrome = fs.readFileSync(`${__dirname}/../../output/svgstore/monochrome.svg`, 'utf-8');
+const figmaIcons = fs.readFileSync(`${__dirname}/../../output/svgstore/icons.svg`, 'utf-8');
+
+const props = {
+    title: (
+        <Fragment>
+            Export your icons as <code class="figma-gradient with-opacity-10">SVG Symbols</code>
+        </Fragment>
+    ),
+    description: (
+        <Fragment>
+            The .svg file contains all components as &lt;symbol&gt;
+            so you can easly use an icon with
+            <code>&lt;svg&gt;&lt;use href="#icon-name" /&gt;&lt;/svg&gt;</code>
+        </Fragment>
+    ),
+    code: `module.exports = {
+        commands: [
+            ['components', {
+                fileId: 'FP7lqd1V00LUaT5zvdklkkZr',
+                onlyFromPages: ['Octicons'],
+                outputters: [
+                    require('@figma-export/output-components-as-svgstore')({
+                        output: './output/svgstore'
+                    })
+                ]
+            }]
+        ]
+    }`
+};
+
+const SvgAsSvgstoreComponent = () => (
+    <CodeBlock {...props}>
+        <Fragment>
+            <div className="svgstore" dangerouslySetInnerHTML={{ __html: figmaMonochrome }} />
+            <div className="svgstore" dangerouslySetInnerHTML={{ __html: figmaIcons }} />
+            <svg className="icon"><use href="#icons-figma-export" /></svg>
+            <svg className="icon"><use href="#icons-figma-logo" /></svg>
+            <svg className="icon"><use href="#monochrome-figma-red" /></svg>
+            <svg className="icon"><use href="#monochrome-figma-purple" /></svg>
+            <svg className="icon"><use href="#monochrome-figma-blue" /></svg>
+            <svg className="icon"><use href="#monochrome-figma-green" /></svg>
+        </Fragment>
+    </CodeBlock>
+);
+
+export default SvgAsSvgstoreComponent;

--- a/packages/website/src/output-components/ComponentsAsSvgstore_monochrome.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore_monochrome.js
@@ -1,0 +1,50 @@
+/* eslint-disable react/no-danger */
+import { Fragment } from 'preact';
+
+import CodeBlock from '../CodeBlock';
+
+const fs = require('fs');
+
+const figmaIcons = fs.readFileSync(`${__dirname}/../../output/svgstore-monochrome/icons.svg`, 'utf-8');
+
+const props = {
+    title: (
+        <Fragment>
+            Export your icons as <code class="figma-gradient with-opacity-10">Monochrome SVG Symbols</code>
+        </Fragment>
+    ),
+    description: (
+        <Fragment>
+            The .svg file contains all components as &lt;symbol&gt; and all <code>fill</code>
+            properties are removed from the svg so you can easily customize the icon color from css.
+        </Fragment>
+    ),
+    code: `module.exports = {
+        commands: [
+            ['components', {
+                fileId: 'FP7lqd1V00LUaT5zvdklkkZr',
+                onlyFromPages: ['Octicons'],
+                outputters: [
+                    require('@figma-export/output-components-as-svgstore')({
+                        output: './output/svgstore-monochrome',
+                        options: {
+                            cleanSymbols: ['fill']
+                        }
+                    })
+                ]
+            }]
+        ]
+    }`
+};
+
+const SvgAsSvgstoreMonochromeComponent = () => (
+    <CodeBlock {...props}>
+        <Fragment>
+            <div className="svgstore" dangerouslySetInnerHTML={{ __html: figmaIcons }} />
+            <svg className="icon"><use href="#unfilled-icons-figma-export" /></svg>
+            <svg className="icon"><use href="#unfilled-icons-figma-logo" /></svg>
+        </Fragment>
+    </CodeBlock>
+);
+
+export default SvgAsSvgstoreMonochromeComponent;


### PR DESCRIPTION
# @figma-export/output-components-as-svgstore

> Outputter for [@figma-export](https://github.com/marcomontalbano/figma-export) that exports components in svg file (`SVG Sprites`).

With this outputter you can export all components as `<symbol>` inside a `.svg` file named with the page name.

This is a sample of the output:

```sh
$ tree output/
# output/
# ├── icons.svg
# └── monochrome.svg
```

Probably you already know what <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/css-sprites/">CSS Sprites</a> are, basically you can combine multiple images into a single image file and use it on a website.

**SVG Sprites** are very similar, but use svg instead of png.

You can read more on <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/svg-sprites-use-better-icon-fonts/">Icon System with SVG Sprites</a> article where you can find how to use them.