### PR TITLE
Component names using 'slashes' create folders

### DIFF
--- a/packages/core/lib/_config.test.js
+++ b/packages/core/lib/_config.test.js
@@ -19,6 +19,10 @@ const component1 = {
     name: 'Figma-Logo',
     type: 'COMPONENT',
     svg: svg.content,
+    figmaExport: {
+        dirname: '.',
+        basename: 'Figma-Logo',
+    },
 };
 
 const component2 = {
@@ -33,6 +37,10 @@ const component3 = {
     name: 'Login',
     type: 'COMPONENT',
     svg: '<svg id="c3"></svg>',
+    figmaExport: {
+        dirname: '.',
+        basename: 'Login',
+    },
 };
 
 const group1 = {

--- a/packages/core/lib/figma.js
+++ b/packages/core/lib/figma.js
@@ -1,18 +1,26 @@
+const { basename, dirname } = require('path');
+
 const Figma = require('figma-js');
 const utils = require('./utils');
 
 const getComponents = (children = []) => {
     let components = [];
 
-    children.forEach((child) => {
-        if (child.type === 'COMPONENT') {
-            components.push(child);
+    children.forEach((component) => {
+        if (component.type === 'COMPONENT') {
+            components.push({
+                ...component,
+                figmaExport: {
+                    dirname: dirname(component.name),
+                    basename: basename(component.name),
+                },
+            });
             return;
         }
 
         components = [
             ...components,
-            ...getComponents(child.children),
+            ...getComponents(component.children),
         ];
     });
 

--- a/packages/output-components-as-es6/index.js
+++ b/packages/output-components-as-es6/index.js
@@ -3,21 +3,7 @@ const path = require('path');
 const makeDir = require('make-dir');
 const svgToMiniDataURI = require('mini-svg-data-uri');
 
-const camelCase = (str) => str.replace(/^([A-Z])|[\s-_]+(\w)/g, (match, p1, p2) => {
-    if (p2) return p2.toUpperCase();
-    return p1.toLowerCase();
-});
-
-const getVariableName = (componentName) => {
-    const trimmedComponentName = componentName.trim();
-    const variableName = camelCase(trimmedComponentName);
-
-    if (/^[\d]+/.test(variableName)) {
-        throw new Error(`"${trimmedComponentName}" - Component names cannot start with a number.`);
-    }
-
-    return variableName;
-};
+const { getVariableName } = require('./utils');
 
 module.exports = ({
     output,
@@ -43,6 +29,10 @@ module.exports = ({
                 case useDataUrl:
                     variableValue = svgToMiniDataURI(svg);
                     break;
+                }
+
+                if (code.includes(`export const ${variableName} =`)) {
+                    throw new Error(`Component "${componentName}" has an error: two components cannot have a same name.`);
                 }
 
                 code += `export const ${variableName} = \`${variableValue}\`;\n`;

--- a/packages/output-components-as-es6/index.test.js
+++ b/packages/output-components-as-es6/index.test.js
@@ -101,4 +101,25 @@ describe('outputter as es6', () => {
             expect(err.message).to.be.equal('"1-icon" thrown an error: component names cannot start with a number.');
         });
     });
+
+    it('should throw an error if two or more components have the same name', async () => {
+        const page = {
+            ...figmaDocument.page1,
+            children: [figmaDocument.component1, figmaDocument.component1],
+        };
+
+        sinon.stub(fs, 'writeFileSync');
+
+        const pages = figma.getPages({ children: [page] });
+        const spyOutputter = sinon.spy(outputter);
+
+        return spyOutputter({
+            output: 'output',
+        })(pages).then(() => {
+            sinon.assert.fail();
+        }).catch((err) => {
+            expect(err).to.be.an('Error');
+            expect(err.message).to.be.equal('Component "Figma-Logo" has an error: two components cannot have a same name.');
+        });
+    });
 });

--- a/packages/output-components-as-es6/index.test.js
+++ b/packages/output-components-as-es6/index.test.js
@@ -98,7 +98,7 @@ describe('outputter as es6', () => {
             sinon.assert.fail();
         }).catch((err) => {
             expect(err).to.be.an('Error');
-            expect(err.message).to.be.equal('"1-icon" - Component names cannot start with a number.');
+            expect(err.message).to.be.equal('"1-icon" thrown an error: component names cannot start with a number.');
         });
     });
 });

--- a/packages/output-components-as-es6/utils.js
+++ b/packages/output-components-as-es6/utils.js
@@ -1,0 +1,21 @@
+const camelCase = (str) => str.replace(/[\])}]+/g, '').replace(/^([A-Z])|[\s-_([/\\{]+(\w)/g, (match, p1, p2) => {
+    if (p2) {
+        return p2.toUpperCase();
+    }
+
+    return p1.toLowerCase();
+});
+
+const getVariableName = (componentName) => {
+    const variableName = camelCase(componentName.trim());
+
+    if (/^[\d]+/.test(variableName)) {
+        throw new Error(`"${componentName.trim()}" thrown an error: component names cannot start with a number.`);
+    }
+
+    return variableName;
+};
+
+module.exports = {
+    getVariableName,
+};

--- a/packages/output-components-as-es6/utils.test.js
+++ b/packages/output-components-as-es6/utils.test.js
@@ -1,0 +1,17 @@
+const { expect } = chai;
+
+const utils = require('./utils');
+
+describe('utils', () => {
+    it('getVariableName', async () => {
+        expect(utils.getVariableName('a')).to.eql('a');
+        expect(utils.getVariableName('a word')).to.eql('aWord');
+        expect(utils.getVariableName('a-word')).to.eql('aWord');
+        expect(utils.getVariableName('a/word')).to.eql('aWord');
+        expect(utils.getVariableName('a\\word')).to.eql('aWord');
+        expect(utils.getVariableName('a[wor]d')).to.eql('aWord');
+        expect(utils.getVariableName('a [word]')).to.eql('aWord');
+        expect(utils.getVariableName('a (word)')).to.eql('aWord');
+        expect(utils.getVariableName('a {word}')).to.eql('aWord');
+    });
+});

--- a/packages/output-components-as-svg/index.js
+++ b/packages/output-components-as-svg/index.js
@@ -3,12 +3,11 @@ const path = require('path');
 const makeDir = require('make-dir');
 
 module.exports = ({ output }) => {
-    makeDir.sync(output);
     return async (pages) => {
         pages.forEach(({ name: pageName, components }) => {
-            components.forEach(({ name: componentName, svg }) => {
-                const filePath = path.resolve(output, `${pageName}-${componentName}.svg`);
-                fs.writeFileSync(filePath, svg);
+            components.forEach(({ svg, figmaExport }) => {
+                const filePath = makeDir.sync(path.resolve(output, figmaExport.dirname));
+                fs.writeFileSync(path.resolve(filePath, `${pageName}-${figmaExport.basename}.svg`), svg);
             });
         });
     };

--- a/packages/website/.figmaexportrc.js
+++ b/packages/website/.figmaexportrc.js
@@ -15,8 +15,12 @@ module.exports = {
 
         ['components', {
             fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['icons', 'monochrome'],
+            onlyFromPages: ['icons', 'monochrome', 'unit-test'],
             outputters: [
+                require('../output-components-as-svg')({
+                    output: './output/svg',
+                }),
+
                 require('../output-components-as-es6')({
                     output: './output/es6-base64',
                     useBase64: true,


### PR DESCRIPTION
Fixed issue #26.

Having a component name like `icon/eye`:
* `@figma-export/output-components-as-svg` will create a folder named `icon` and will store the `eye.svg` inside.
* `@figma-export/output-components-as-es6` will generate a variable named `iconEye`.
