### PR TITLE
Change options to a more meaningful name (output-components-as-svgstore)

### DIFF
--- a/packages/output-components-as-svgstore/README.md
+++ b/packages/output-components-as-svgstore/README.md
@@ -41,13 +41,13 @@ module.exports = {
 
 `output` is **mandatory**.
 
-`getIconId` and `options` are **optional**.
+`getIconId` and `svgstoreConfig` are **optional**.
 
 ```js
 require('@figma-export/output-components-as-svgstore')({
     output: './output',
     getIconId: (options) => `${options.pageName}/${options.componentName}`,
-    options: {},
+    svgstoreConfig: {},
 })
 ```
 

--- a/packages/output-components-as-svgstore/src/index.ts
+++ b/packages/output-components-as-svgstore/src/index.ts
@@ -8,28 +8,28 @@ import path = require('path');
 
 type Options = {
     output: string;
-    options?: {};
+    svgstoreConfig?: {};
     getIconId?: (options: FigmaExport.OutputterParamOption) => string;
 }
 
 export = ({
     output,
     getIconId = (options): string => `${options.pageName}/${options.componentName}`,
-    options = {},
+    svgstoreConfig = {},
 }: Options): FigmaExport.Outputter => {
     makeDir.sync(output);
     return async (pages): Promise<void> => {
         pages.forEach(({ name: pageName, components }) => {
-            const sprites = svgstore(options);
+            const sprites = svgstore(svgstoreConfig);
 
             components.forEach(({ name: componentName, svg, figmaExport }) => {
-                const opts = {
+                const options = {
                     pageName,
                     componentName,
                     ...figmaExport,
                 };
 
-                sprites.add(getIconId(opts), svg);
+                sprites.add(getIconId(options), svg);
             });
 
             const filePath = path.resolve(output, `${pageName}.svg`);

--- a/packages/website/.figmaexportrc.js
+++ b/packages/website/.figmaexportrc.js
@@ -67,7 +67,7 @@ module.exports = {
                 require('../output-components-as-svgstore')({
                     output: './output/svgstore-monochrome',
                     getIconId: (options) => `[unfilled] ${options.pageName}/${options.componentName}`,
-                    options: {
+                    svgstoreConfig: {
                         cleanSymbols: ['fill']
                     }
                 }),

--- a/packages/website/src/output-components/ComponentsAsSvgstore_monochrome.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore_monochrome.js
@@ -27,7 +27,7 @@ const props = {
                 outputters: [
                     require('@figma-export/output-components-as-svgstore')({
                         output: './output/svgstore-monochrome',
-                        options: {
+                        svgstoreConfig: {
                             cleanSymbols: ['fill']
                         }
                     })


### PR DESCRIPTION
:boom: **contains breaking changes** on `output-components-as-svgstore`.

Renamed param `options` to `svgstoreConfig`.