### PR TITLE
Add `styles` command to `figma-export`

### DIFF
--- a/packages/cli/src/commands/styles.ts
+++ b/packages/cli/src/commands/styles.ts
@@ -9,30 +9,26 @@ import ora = require('ora');
 
 const spinner = ora({});
 
-class ComponentsCommand extends Command {
+class StylesCommand extends Command {
     async run(): Promise<void> {
         const {
             args: {
                 fileId,
             },
             flags: {
-                page,
                 output,
                 outputter = [],
-                transformer = [],
             },
-        } = this.parse(ComponentsCommand);
+        } = this.parse(StylesCommand);
 
-        spinner.info(`Exporting ${fileId} with [${transformer.join(', ')}] as [${outputter.join(', ')}]`);
+        spinner.info(`Exporting ${fileId} as [${outputter.join(', ')}]`);
 
         spinner.start();
 
-        figmaExport.components({
+        figmaExport.styles({
             fileId,
             token: process.env.FIGMA_TOKEN || '',
-            onlyFromPages: page,
-            transformers: requirePackages<FigmaExport.StringTransformer>(transformer),
-            outputters: requirePackages<FigmaExport.ComponentOutputter>(outputter, { output }),
+            outputters: requirePackages<FigmaExport.StyleOutputter>(outputter, { output }),
             log: (message: string) => { spinner.text = message; },
         }).then(() => {
             spinner.stop();
@@ -43,21 +39,17 @@ class ComponentsCommand extends Command {
     }
 }
 
-ComponentsCommand.description = `export components from a Figma file
+StylesCommand.description = `export styles from a Figma file
 `;
 
-ComponentsCommand.args = [
+StylesCommand.args = [
     {
         name: 'fileId',
         required: true,
     },
 ];
 
-ComponentsCommand.flags = {
-    page: commandFlags.string({
-        char: 'p',
-        description: 'Figma page names (defaults to \'all pages\')',
-    }),
+StylesCommand.flags = {
     output: commandFlags.string({
         char: 'o',
         description: 'Output directory',
@@ -69,11 +61,6 @@ ComponentsCommand.flags = {
         description: 'Outputter module or path',
         multiple: true,
     }),
-    transformer: commandFlags.string({
-        char: 'T',
-        description: 'Transformer module or path',
-        multiple: true,
-    }),
 };
 
-module.exports = ComponentsCommand;
+module.exports = StylesCommand;

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,0 +1,21 @@
+import fs = require('fs');
+import path = require('path');
+
+const resolveNameOrPath = (nameOrPath: string): string => {
+    const absolutePath = path.resolve(nameOrPath);
+    return fs.existsSync(absolutePath) ? absolutePath : nameOrPath;
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const requirePackages = <T extends Function>(packages: (T | string)[], baseOptions = {}): T[] => {
+    return packages.map((pkg) => {
+        if (typeof pkg === 'function') {
+            return pkg;
+        }
+
+        const pkgNameOrPath = resolveNameOrPath(pkg);
+
+        // eslint-disable-next-line import/no-dynamic-require, global-require, @typescript-eslint/no-var-requires
+        return require(pkgNameOrPath)(baseOptions);
+    });
+};

--- a/packages/core/src/lib/export-styles.ts
+++ b/packages/core/src/lib/export-styles.ts
@@ -6,8 +6,6 @@ import { fetchStyles, parseStyles } from './figmaStyles';
 type Options = {
     token: string;
     fileId: string;
-    onlyFromPages?: string[];
-    // transformers?: FigmaExport.StringTransformer[];
     outputters?: FigmaExport.StyleOutputter[];
     log?: (msg: string) => void;
 }
@@ -15,7 +13,6 @@ type Options = {
 export const styles = async ({
     token,
     fileId,
-    // transformers = [],
     outputters = [],
     log = (msg): void => {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
Usage

```sh
# export figma styles as .scss variables
npx -p @figma-export/cli -p @figma-export/output-styles-as-sass figma-export styles RSzpKJcnb6uBRQ3rOfLIyUs5 -O @figma-export/output-styles-as-sass
```

Closes #64 