### PR TITLE
Create `LESS` styles-outputter

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ module.exports = {
 
         ['styles', {
             fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['figma-styles'],
             outputters: [
                 require('@figma-export/output-styles-as-sass')({
                     output: './output/styles'

--- a/packages/output-styles-as-less/.npmignore
+++ b/packages/output-styles-as-less/.npmignore
@@ -1,0 +1,3 @@
+src
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/output-styles-as-less/README.md
+++ b/packages/output-styles-as-less/README.md
@@ -1,0 +1,61 @@
+# @figma-export/output-styles-as-less
+
+> Styles Outputter for [@figma-export](https://github.com/marcomontalbano/figma-export) that exports styles to LESS.
+
+With this outputter you can export all the styles as variables inside a `.less` file.
+
+This is a sample of the output:
+
+```sh
+$ tree output/
+# output/
+# └── _variables.less
+```
+
+
+## .figmaexportrc.js
+
+You can easily add this outputter to your `.figmaexportrc.js`:
+
+```js
+module.exports = {
+    commands: [
+        ['styles', {
+            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+            onlyFromPages: ['figma-styles'],
+            outputters: [
+                require('@figma-export/output-styles-as-less')({
+                    output: './output'
+                })
+            ]
+        }],
+    ]
+}
+```
+
+`output` is **mandatory**.
+
+`getFilename` are **optional**.
+
+```js
+require('@figma-export/output-styles-as-less')({
+    output: './output',
+    getFilename: () => '_variables',
+})
+```
+
+> *defaults may change, please refer to `./src/index.ts`*
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @figma-export/output-styles-as-less
+```
+
+or using yarn:
+
+```sh
+yarn add @figma-export/output-styles-as-less --dev
+```

--- a/packages/output-styles-as-less/README.md
+++ b/packages/output-styles-as-less/README.md
@@ -22,7 +22,6 @@ module.exports = {
     commands: [
         ['styles', {
             fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['figma-styles'],
             outputters: [
                 require('@figma-export/output-styles-as-less')({
                     output: './output'

--- a/packages/output-styles-as-less/package.json
+++ b/packages/output-styles-as-less/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@figma-export/output-styles-as-less",
+    "version": "3.0.0-alpha.3",
+    "description": "Outputter for @figma-export that exports styles to LESS",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/marcomontalbano/figma-exporter.git",
+        "directory": "packages/output-styles-as-less"
+    },
+    "author": "Marco Montalbano <me@marcomontalbano.com>",
+    "license": "MIT",
+    "publishConfig": {
+        "access": "public"
+    },
+    "dependencies": {
+        "@figma-export/types": "^3.0.0-alpha.3",
+        "make-dir": "~3.1.0"
+    },
+    "engines": {
+        "node": ">= 10.13 <= 14.x"
+    }
+}

--- a/packages/output-styles-as-less/src/index.test.ts
+++ b/packages/output-styles-as-less/src/index.test.ts
@@ -1,0 +1,277 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import {
+    StyleNode,
+    FillStyle,
+    EffectStyle,
+    Style,
+} from '@figma-export/types';
+
+// eslint-disable-next-line import/order
+import fs = require('fs');
+import outputter = require('./index');
+
+const mockFill = (fills: FillStyle[] = [], visible = true): Style => ({
+    fills,
+    visible,
+    name: 'variable-name',
+    comment: 'lorem ipsum',
+    styleType: 'FILL',
+    originalNode: { ...({} as StyleNode) },
+});
+
+const mockSolid = (value: string, visible = true): FillStyle => ({
+    value,
+    visible,
+    type: 'SOLID',
+    color: {
+        a: 1, r: 255, g: 255, b: 255, rgba: 'rgba(255, 255, 255, 1)',
+    },
+});
+
+const mockGradientLinear = (value: string, visible = true): FillStyle => ({
+    value,
+    visible,
+    type: 'GRADIENT_LINEAR',
+    gradientStops: [],
+    angle: '100deg',
+});
+
+const mockEffect = (effects: EffectStyle[] = [], visible = true): Style => ({
+    effects,
+    visible,
+    name: 'variable-name',
+    comment: '',
+    styleType: 'EFFECT',
+    originalNode: { ...({} as StyleNode) },
+});
+
+const mockShadow = (value: string, visible = true): EffectStyle => ({
+    value,
+    visible,
+    type: 'INNER_SHADOW',
+    color: {
+        a: 1, r: 255, g: 255, b: 255, rgba: 'rgba(255, 255, 255, 1)',
+    },
+    inset: false,
+    blurRadius: 10,
+    spreadRadius: 10,
+    offset: { x: 10, y: 10 },
+});
+
+const mockBlur = (value: string, visible = true): EffectStyle => ({
+    value,
+    visible,
+    type: 'LAYER_BLUR',
+    blurRadius: 10,
+});
+
+const mockText = (visible = true): Style => ({
+    style: {
+        fontFamily: 'Verdana',
+        fontSize: 12,
+        fontStyle: 'italic',
+        fontVariant: 'normal',
+        fontWeight: 100,
+        letterSpacing: 10,
+        lineHeight: 12,
+        textAlign: 'left',
+        textDecoration: 'none',
+        textTransform: 'uppercase',
+        verticalAlign: 'middle',
+    },
+    visible,
+    name: 'variable-name',
+    comment: '',
+    styleType: 'TEXT',
+    originalNode: { ...({} as StyleNode) },
+});
+
+describe('style output as less', () => {
+    let writeFileSync;
+
+    beforeEach(() => {
+        writeFileSync = sinon.stub(fs, 'writeFileSync');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should not print anything if style is not visible', async () => {
+        await outputter({
+            output: 'output-folder',
+        })([
+            mockFill([
+                mockSolid('solid-1'),
+            ], false),
+        ]);
+
+        expect(writeFileSync).to.be.calledOnce;
+        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.less', '');
+    });
+
+    it('should be able to change the filename, the extension and output folder', async () => {
+        await outputter({
+            output: 'output-folder',
+            getFilename: () => '_figma-styles',
+        })([]);
+
+        expect(writeFileSync).to.be.calledOnce;
+        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_figma-styles.less');
+    });
+
+    describe('colors', () => {
+        it('should not print anything if fill is not visible', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockFill([
+                    mockSolid('solid-1', false),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.less', '');
+        });
+
+        it('should be able to extract a solid color', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockFill([
+                    mockSolid('rgba(solid-1)', true),
+                    mockSolid('rgba(solid-2)', false),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n'
+                + '/**\n'
+                + ' * lorem ipsum\n'
+                + ' */\n'
+                + '@variable-name: rgba(solid-1);\n',
+            );
+        });
+
+        it('should be able to extract a linear gradient', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockFill([
+                    mockGradientLinear('linear-gradient-1'),
+                    mockGradientLinear('linear-gradient-2'),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n'
+                + '/**\n'
+                + ' * lorem ipsum\n'
+                + ' */\n'
+                + '@variable-name: linear-gradient-1, linear-gradient-2;\n',
+            );
+        });
+    });
+
+    describe('effects', () => {
+        it('should be able to extract a box-shadow', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockEffect([
+                    mockShadow('shadow-effect-1'),
+                    mockShadow('shadow-effect-2'),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n\n'
+                + '@variable-name: shadow-effect-1, shadow-effect-2;\n',
+            );
+        });
+
+        it('should be able to extract a filter: blur()', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockEffect([
+                    mockBlur('blur-effect'),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n\n'
+                + '@variable-name: blur-effect;\n',
+            );
+        });
+
+        it('should not combine shadow and blur effects', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockEffect([
+                    mockShadow('shadow-effect-1'),
+                    mockBlur('blur-effect-1'),
+                    mockShadow('shadow-effect-2'),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWith(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n\n'
+                + '@variable-name: shadow-effect-1, shadow-effect-2;\n',
+            );
+        });
+    });
+
+    describe('texts', () => {
+        it('should be able to extract a text', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockText(),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWith(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n\n'
+                + '#variable-name() {\n'
+                + 'font-family: "Verdana";\n'
+                + 'font-size: 12px;\n'
+                + 'font-style: italic;\n'
+                + 'font-variant: normal;\n'
+                + 'font-weight: 100;\n'
+                + 'letter-spacing: 10px;\n'
+                + 'line-height: 12px;\n'
+                + 'text-align: left;\n'
+                + 'text-decoration: none;\n'
+                + 'text-transform: uppercase;\n'
+                + 'vertical-align: middle;\n'
+                + '};\n',
+            );
+        });
+    });
+});

--- a/packages/output-styles-as-less/src/index.ts
+++ b/packages/output-styles-as-less/src/index.ts
@@ -45,7 +45,7 @@ export = ({
                             .map((effect) => effect.value)
                             .join(', ');
 
-                        // TODO: add to documentation. "you cannot combine shadow and blur effects"
+                        // Shadow and Blur effects cannot be combined together since they use two different CSS properties.
                         text += writeVariable(style.comment, style.name, boxShadowValue || filterBlurValue);
 
                         break;
@@ -68,10 +68,6 @@ export = ({
 
                         text += writeMap(style.comment, style.name, value);
 
-                        break;
-                    }
-
-                    case 'GRID': {
                         break;
                     }
                 }

--- a/packages/output-styles-as-less/src/index.ts
+++ b/packages/output-styles-as-less/src/index.ts
@@ -1,0 +1,84 @@
+import * as FigmaExport from '@figma-export/types';
+import { writeVariable, writeMap } from './utils';
+
+import fs = require('fs');
+import path = require('path');
+import makeDir = require('make-dir');
+
+type Options = {
+    output: string;
+    getFilename?: () => string;
+}
+
+export = ({
+    output,
+    getFilename = () => '_variables',
+}: Options): FigmaExport.StyleOutputter => {
+    return async (styles) => {
+        let text = '';
+
+        styles.forEach((style) => {
+            if (style.visible) {
+                // eslint-disable-next-line default-case
+                switch (style.styleType) {
+                    case 'FILL': {
+                        const value = style.fills
+                            .filter((fill) => fill.visible)
+                            .map((fill) => fill.value)
+                            .join(', ');
+
+                        text += writeVariable(style.comment, style.name, value);
+
+                        break;
+                    }
+
+                    case 'EFFECT': {
+                        const visibleEffects = style.effects.filter((effect) => effect.visible);
+
+                        const boxShadowValue = visibleEffects
+                            .filter((effect) => effect.type === 'INNER_SHADOW' || effect.type === 'DROP_SHADOW')
+                            .map((effect) => effect.value)
+                            .join(', ');
+
+                        const filterBlurValue = visibleEffects
+                            .filter((effect) => effect.type === 'LAYER_BLUR')
+                            .map((effect) => effect.value)
+                            .join(', ');
+
+                        // TODO: add to documentation. "you cannot combine shadow and blur effects"
+                        text += writeVariable(style.comment, style.name, boxShadowValue || filterBlurValue);
+
+                        break;
+                    }
+
+                    case 'TEXT': {
+                        const value = `{
+                            font-family: "${style.style.fontFamily}";
+                            font-size: ${style.style.fontSize}px;
+                            font-style: ${style.style.fontStyle};
+                            font-variant: ${style.style.fontVariant};
+                            font-weight: ${style.style.fontWeight};
+                            letter-spacing: ${style.style.letterSpacing}px;
+                            line-height: ${style.style.lineHeight}px;
+                            text-align: ${style.style.textAlign};
+                            text-decoration: ${style.style.textDecoration};
+                            text-transform: ${style.style.textTransform};
+                            vertical-align: ${style.style.verticalAlign};
+                        }`;
+
+                        text += writeMap(style.comment, style.name, value);
+
+                        break;
+                    }
+
+                    case 'GRID': {
+                        break;
+                    }
+                }
+            }
+        });
+
+        const filePath = makeDir.sync(path.resolve(output));
+        fs.writeFileSync(path.resolve(filePath, `${getFilename()}.less`), text);
+    };
+};

--- a/packages/output-styles-as-less/src/utils.test.ts
+++ b/packages/output-styles-as-less/src/utils.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+
+import { writeVariable, writeMap } from './utils';
+
+describe('utils', () => {
+    describe('writeVariable', () => {
+        it('should be able to print-out simple variable', () => {
+            const text = writeVariable(
+                'This is a comment',
+                'variable-name', '#fff',
+            );
+
+            expect(text).to.eql(
+                // eslint-disable-next-line indent
+                    '\n'
+                + '/**\n'
+                + ' * This is a comment\n'
+                + ' */\n'
+                + '@variable-name: #fff;\n',
+            );
+        });
+
+        it('should be able to print-out simple variable with an empty comment', () => {
+            const text = writeVariable('', 'variable-name', '#fff');
+            expect(text).to.eql('\n\n@variable-name: #fff;\n');
+        });
+
+        it('should be able to print-out a comment in multiline', () => {
+            const text = writeVariable(
+                'This is a comment\nin two lines',
+                'variable-name', '#fff',
+            );
+
+            expect(text).to.eql(
+                // eslint-disable-next-line indent
+                    '\n'
+                + '/**\n'
+                + ' * This is a comment\n'
+                + ' * in two lines\n'
+                + ' */\n'
+                + '@variable-name: #fff;\n',
+            );
+        });
+    });
+
+    describe('writeMap', () => {
+        it('should be able to print-out a complex variable', () => {
+            const text = writeMap(
+                'This is a comment\nin two lines',
+                'variable-name', '{\ncolor-1: #fff;\ncolor-2: #000;\n}',
+            );
+
+            expect(text).to.eql(
+                // eslint-disable-next-line indent
+                    '\n'
+                + '/**\n'
+                + ' * This is a comment\n'
+                + ' * in two lines\n'
+                + ' */\n'
+                + '#variable-name() {\n'
+                + 'color-1: #fff;\n'
+                + 'color-2: #000;\n'
+                + '};\n',
+            );
+        });
+    });
+});

--- a/packages/output-styles-as-less/src/utils.test.ts
+++ b/packages/output-styles-as-less/src/utils.test.ts
@@ -4,6 +4,15 @@ import { writeVariable, writeMap } from './utils';
 
 describe('utils', () => {
     describe('writeVariable', () => {
+        it('should return empty string is the value is empty', () => {
+            const text = writeVariable(
+                'This is a comment',
+                'variable-name', '',
+            );
+
+            expect(text).to.eql('');
+        });
+
         it('should be able to print-out simple variable', () => {
             const text = writeVariable(
                 'This is a comment',
@@ -44,6 +53,15 @@ describe('utils', () => {
     });
 
     describe('writeMap', () => {
+        it('should return empty string is the value is empty', () => {
+            const text = writeMap(
+                'This is a comment',
+                'variable-name', '',
+            );
+
+            expect(text).to.eql('');
+        });
+
         it('should be able to print-out a complex variable', () => {
             const text = writeMap(
                 'This is a comment\nin two lines',

--- a/packages/output-styles-as-less/src/utils.ts
+++ b/packages/output-styles-as-less/src/utils.ts
@@ -1,0 +1,34 @@
+const sanitizeText = (text: string): string => {
+    return text
+        .replace(/^[^\S\r\n]+/gm, '')
+        .replace(/^\*/gm, ' *')
+        .replace(/^"/gm, '  "');
+};
+
+const writeComment = (message: string): string => {
+    return message && `/**
+                        * ${message.replace(/\*\//g, '').split('\n').join('\n  * ')}
+                        */`;
+};
+
+export const writeVariable = (comment: string, name: string, value: string): string => {
+    if (value) {
+        return sanitizeText(`
+            ${writeComment(comment)}
+            @${name}: ${value};
+        `);
+    }
+
+    return '';
+};
+
+export const writeMap = (comment: string, name: string, value: string): string => {
+    if (value) {
+        return sanitizeText(`
+            ${writeComment(comment)}
+            #${name}() ${value};
+        `);
+    }
+
+    return '';
+};

--- a/packages/output-styles-as-less/tsconfig.json
+++ b/packages/output-styles-as-less/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../types"},
+  ]
+}

--- a/packages/output-styles-as-sass/README.md
+++ b/packages/output-styles-as-sass/README.md
@@ -22,7 +22,6 @@ module.exports = {
     commands: [
         ['styles', {
             fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['figma-styles'],
             outputters: [
                 require('@figma-export/output-styles-as-sass')({
                     output: './output'

--- a/packages/output-styles-as-sass/src/index.ts
+++ b/packages/output-styles-as-sass/src/index.ts
@@ -50,7 +50,7 @@ export = ({
                             .map((effect) => effect.value)
                             .join(', ');
 
-                        // TODO: add to documentation. "you cannot combine shadow and blur effects"
+                        // Shadow and Blur effects cannot be combined together since they use two different CSS properties.
                         text += writeVariable(style.comment, style.name, boxShadowValue || filterBlurValue, extension);
 
                         break;
@@ -73,10 +73,6 @@ export = ({
 
                         text += writeVariable(style.comment, style.name, value, extension);
 
-                        break;
-                    }
-
-                    case 'GRID': {
                         break;
                     }
                 }

--- a/packages/output-styles-as-sass/src/utils.test.ts
+++ b/packages/output-styles-as-sass/src/utils.test.ts
@@ -7,6 +7,16 @@ describe('utils', () => {
         describe('SCSS', () => {
             const extension = 'SCSS';
 
+            it('should return empty string is the value is empty', () => {
+                const text = writeVariable(
+                    'This is a comment',
+                    'variable-name', '',
+                    extension,
+                );
+
+                expect(text).to.eql('');
+            });
+
             it('should be able to print-out simple variable', () => {
                 const text = writeVariable(
                     'This is a comment',
@@ -71,6 +81,16 @@ describe('utils', () => {
 
         describe('SASS', () => {
             const extension = 'SASS';
+
+            it('should return empty string is the value is empty', () => {
+                const text = writeVariable(
+                    'This is a comment',
+                    'variable-name', '',
+                    extension,
+                );
+
+                expect(text).to.eql('');
+            });
 
             it('should be able to print-out simple variable', () => {
                 const text = writeVariable(

--- a/packages/website/.figmaexportrc.js
+++ b/packages/website/.figmaexportrc.js
@@ -5,7 +5,6 @@ module.exports = {
     commands: [
         ['styles', {
             fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['figma-styles'],
             outputters: [
                 require('../output-styles-as-sass')({
                     output: './output/figma-styles'

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -24,12 +24,12 @@
         <meta name="msapplication-TileImage" content="./images/icon/ms-icon-144x144.png">
         <meta name="theme-color" content="#ffffff">
 
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/themes/prism-solarizedlight.min.css" rel="stylesheet" />
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/themes/prism-solarizedlight.min.css" rel="stylesheet" />
         <link rel="stylesheet" href="./scss/index.scss" />
     </head>
     <body>
         <div id="root"></div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/prism.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/prism.min.js"></script>
         <script src="./src/index.js"></script>
     </body>
 </html>

--- a/packages/website/src/output-components/ComponentsAsES6_base64.js
+++ b/packages/website/src/output-components/ComponentsAsES6_base64.js
@@ -21,20 +21,21 @@ const props = {
             Data URL <code>data:image/svg+xml;base64,</code>
         </Fragment>
     ),
-    code: `module.exports = {
-        commands: [
-            ['components', {
-                fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-                onlyFromPages: ['icons', 'monochrome'],
-                outputters: [
-                    require('@figma-export/output-components-as-es6')({
-                        output: './output/es6-base64',
-                        useBase64: true,
-                    })
-                ]
-            }]
-        ]
-    }`
+    code: `\
+module.exports = {
+    commands: [
+        ['components', {
+            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+            onlyFromPages: ['icons', 'monochrome'],
+            outputters: [
+                require('@figma-export/output-components-as-es6')({
+                    output: './output/es6-base64',
+                    useBase64: true,
+                })
+            ]
+        }]
+    ]
+}`
 };
 
 const Icon = ({ svg }) => (

--- a/packages/website/src/output-components/ComponentsAsES6_dataUrl.js
+++ b/packages/website/src/output-components/ComponentsAsES6_dataUrl.js
@@ -19,20 +19,21 @@ const props = {
             The .js file contains all components as Data URL so you can easly put this value into the src of your images. <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/probably-dont-base64-svg/">This is the best way</a> to load an svg as image.
         </Fragment>
     ),
-    code: `module.exports = {
-        commands: [
-            ['components', {
-                fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-                onlyFromPages: ['icons', 'monochrome'],
-                outputters: [
-                    require('@figma-export/output-components-as-es6')({
-                        output: './output/es6-dataurl',
-                        useDataUrl: true,
-                    })
-                ]
-            }]
-        ]
-    }`
+    code: `\
+module.exports = {
+    commands: [
+        ['components', {
+            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+            onlyFromPages: ['icons', 'monochrome'],
+            outputters: [
+                require('@figma-export/output-components-as-es6')({
+                    output: './output/es6-dataurl',
+                    useDataUrl: true,
+                })
+            ]
+        }]
+    ]
+}`
 };
 
 const SvgAsES6ComponentDataUrl = () => (

--- a/packages/website/src/output-components/ComponentsAsSvgr_default.js
+++ b/packages/website/src/output-components/ComponentsAsSvgr_default.js
@@ -25,19 +25,20 @@ const props = {
             <code>import {`{ Squirrel }`} from './output/octicons-by-github';</code>
         </Fragment>
     ),
-    code: `module.exports = {
-        commands: [
-            ['components', {
-                fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-                onlyFromPages: ['octicons-by-github'],
-                outputters: [
-                    require('@figma-export/output-components-as-svgr')({
-                        output: './output'
-                    })
-                ]
-            }]
-        ]
-    }`
+    code: `\
+module.exports = {
+    commands: [
+        ['components', {
+            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+            onlyFromPages: ['octicons-by-github'],
+            outputters: [
+                require('@figma-export/output-components-as-svgr')({
+                    output: './output'
+                })
+            ]
+        }]
+    ]
+}`
 };
 
 const ComponentsAsSvgrDefault = () => (

--- a/packages/website/src/output-components/ComponentsAsSvgstore_default.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore_default.js
@@ -21,19 +21,20 @@ const props = {
             <code>&lt;svg&gt;&lt;use href="#icon-name" /&gt;&lt;/svg&gt;</code>
         </Fragment>
     ),
-    code: `module.exports = {
-        commands: [
-            ['components', {
-                fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-                onlyFromPages: ['icons', 'monochrome'],
-                outputters: [
-                    require('@figma-export/output-components-as-svgstore')({
-                        output: './output/svgstore'
-                    })
-                ]
-            }]
-        ]
-    }`
+    code: `\
+module.exports = {
+    commands: [
+        ['components', {
+            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+            onlyFromPages: ['icons', 'monochrome'],
+            outputters: [
+                require('@figma-export/output-components-as-svgstore')({
+                    output: './output/svgstore'
+                })
+            ]
+        }]
+    ]
+}`
 };
 
 const SvgAsSvgstoreComponent = () => (

--- a/packages/website/src/output-components/ComponentsAsSvgstore_monochrome.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore_monochrome.js
@@ -19,22 +19,23 @@ const props = {
             properties are removed from the svg so you can easily customize the icon color from css.
         </Fragment>
     ),
-    code: `module.exports = {
-        commands: [
-            ['components', {
-                fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-                onlyFromPages: ['icons'],
-                outputters: [
-                    require('@figma-export/output-components-as-svgstore')({
-                        output: './output/svgstore-monochrome',
-                        svgstoreConfig: {
-                            cleanSymbols: ['fill']
-                        }
-                    })
-                ]
-            }]
-        ]
-    }`
+    code: `\
+module.exports = {
+    commands: [
+        ['components', {
+            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+            onlyFromPages: ['icons'],
+            outputters: [
+                require('@figma-export/output-components-as-svgstore')({
+                    output: './output/svgstore-monochrome',
+                    svgstoreConfig: {
+                        cleanSymbols: ['fill']
+                    }
+                })
+            ]
+        }]
+    ]
+}`
 };
 
 const SvgAsSvgstoreMonochromeComponent = () => (

--- a/packages/website/src/output-styles/AsLess.js
+++ b/packages/website/src/output-styles/AsLess.js
@@ -4,7 +4,7 @@ import CodeBlock from '../CodeBlock';
 const props = {
     title: (
         <Fragment>
-            Export your styles as <code class="figma-gradient with-opacity-10">SASS</code> and <code class="figma-gradient with-opacity-10">SCSS</code>
+            Export your styles as <code class="figma-gradient with-opacity-10">LESS</code>
         </Fragment>
     ),
     description: (
@@ -21,12 +21,8 @@ module.exports = {
             fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
             onlyFromPages: ['figma-styles'],
             outputters: [
-                require('@figma-export/output-styles-as-sass')({
-                    output: './output/scss',
-                }),
-                require('@figma-export/output-styles-as-sass')({
-                    output: './output/sass',
-                    getExtension: () => 'SASS',
+                require('@figma-export/output-styles-as-less')({
+                    output: './output/less',
                 })
             ]
         }]
@@ -34,8 +30,8 @@ module.exports = {
 }`
 };
 
-const AsSass = () => (
+const AsLess = () => (
     <CodeBlock {...props} />
 );
 
-export default AsSass;
+export default AsLess;

--- a/packages/website/src/output-styles/AsLess.js
+++ b/packages/website/src/output-styles/AsLess.js
@@ -19,7 +19,6 @@ module.exports = {
     commands: [
         ['styles', {
             fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['figma-styles'],
             outputters: [
                 require('@figma-export/output-styles-as-less')({
                     output: './output/less',

--- a/packages/website/src/output-styles/AsSass.js
+++ b/packages/website/src/output-styles/AsSass.js
@@ -19,7 +19,6 @@ module.exports = {
     commands: [
         ['styles', {
             fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['figma-styles'],
             outputters: [
                 require('@figma-export/output-styles-as-sass')({
                     output: './output/scss',

--- a/packages/website/src/output-styles/FigmaStyles.js
+++ b/packages/website/src/output-styles/FigmaStyles.js
@@ -1,4 +1,5 @@
 import AsSass from './AsSass';
+import AsLess from './AsLess';
 
 const FigmaStyles = () => (
     <div className="section-block container text-center">
@@ -47,6 +48,7 @@ const FigmaStyles = () => (
         </div>
 
         <AsSass />
+        <AsLess />
     </div>
 );
 


### PR DESCRIPTION
With this outputter you can export all the styles as variables inside a `.less` file.

This is a sample of the output:

```sh
$ tree output/
# output/
# └── _variables.less
```


## .figmaexportrc.js

You can easily add this outputter to your `.figmaexportrc.js`:

```js
module.exports = {
    commands: [
        ['styles', {
            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
            outputters: [
                require('@figma-export/output-styles-as-less')({
                    output: './output'
                })
            ]
        }],
    ]
}
```

`output` is **mandatory**.

`getFilename` are **optional**.

```js
require('@figma-export/output-styles-as-less')({
    output: './output',
    getFilename: () => '_variables',
})
```

> *defaults may change, please refer to `./src/index.ts`*


Closes #66 