### PR TITLE
Create `CSS` styles-outputter

### DIFF
--- a/packages/output-styles-as-css/.npmignore
+++ b/packages/output-styles-as-css/.npmignore
@@ -1,0 +1,3 @@
+src
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/output-styles-as-css/README.md
+++ b/packages/output-styles-as-css/README.md
@@ -1,0 +1,60 @@
+# @figma-export/output-styles-as-css
+
+> Styles Outputter for [@figma-export](https://github.com/marcomontalbano/figma-export) that exports styles to CSS.
+
+With this outputter you can export all the styles as variables inside a `.css` file.
+
+This is a sample of the output:
+
+```sh
+$ tree output/
+# output/
+# └── _variables.css
+```
+
+
+## .figmaexportrc.js
+
+You can easily add this outputter to your `.figmaexportrc.js`:
+
+```js
+module.exports = {
+    commands: [
+        ['styles', {
+            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+            outputters: [
+                require('@figma-export/output-styles-as-css')({
+                    output: './output'
+                })
+            ]
+        }],
+    ]
+}
+```
+
+`output` is **mandatory**.
+
+`getFilename` are **optional**.
+
+```js
+require('@figma-export/output-styles-as-css')({
+    output: './output',
+    getFilename: () => '_variables',
+})
+```
+
+> *defaults may change, please refer to `./src/index.ts`*
+
+## Install
+
+Using npm:
+
+```sh
+npm install --save-dev @figma-export/output-styles-as-css
+```
+
+or using yarn:
+
+```sh
+yarn add @figma-export/output-styles-as-css --dev
+```

--- a/packages/output-styles-as-css/package.json
+++ b/packages/output-styles-as-css/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@figma-export/output-styles-as-css",
+    "version": "3.0.0-alpha.4",
+    "description": "Outputter for @figma-export that exports styles to CSS",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/marcomontalbano/figma-exporter.git",
+        "directory": "packages/output-styles-as-css"
+    },
+    "author": "Marco Montalbano <me@marcomontalbano.com>",
+    "license": "MIT",
+    "publishConfig": {
+        "access": "public"
+    },
+    "dependencies": {
+        "@figma-export/types": "^3.0.0-alpha.4",
+        "make-dir": "~3.1.0"
+    },
+    "engines": {
+        "node": ">= 10.13 <= 14.x"
+    }
+}

--- a/packages/output-styles-as-css/src/index.test.ts
+++ b/packages/output-styles-as-css/src/index.test.ts
@@ -1,0 +1,312 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import {
+    StyleNode,
+    FillStyle,
+    EffectStyle,
+    Style,
+} from '@figma-export/types';
+
+// eslint-disable-next-line import/order
+import fs = require('fs');
+import outputter = require('./index');
+
+const mockFill = (fills: FillStyle[] = [], visible = true): Style => ({
+    fills,
+    visible,
+    name: 'variable-name',
+    comment: 'lorem ipsum',
+    styleType: 'FILL',
+    originalNode: { ...({} as StyleNode) },
+});
+
+const mockSolid = (value: string, visible = true): FillStyle => ({
+    value,
+    visible,
+    type: 'SOLID',
+    color: {
+        a: 1, r: 255, g: 255, b: 255, rgba: 'rgba(255, 255, 255, 1)',
+    },
+});
+
+const mockGradientLinear = (value: string, visible = true): FillStyle => ({
+    value,
+    visible,
+    type: 'GRADIENT_LINEAR',
+    gradientStops: [],
+    angle: '100deg',
+});
+
+const mockEffect = (effects: EffectStyle[] = [], visible = true): Style => ({
+    effects,
+    visible,
+    name: 'variable-name',
+    comment: '',
+    styleType: 'EFFECT',
+    originalNode: { ...({} as StyleNode) },
+});
+
+const mockShadow = (value: string, visible = true): EffectStyle => ({
+    value,
+    visible,
+    type: 'INNER_SHADOW',
+    color: {
+        a: 1, r: 255, g: 255, b: 255, rgba: 'rgba(255, 255, 255, 1)',
+    },
+    inset: false,
+    blurRadius: 10,
+    spreadRadius: 10,
+    offset: { x: 10, y: 10 },
+});
+
+const mockBlur = (value: string, visible = true): EffectStyle => ({
+    value,
+    visible,
+    type: 'LAYER_BLUR',
+    blurRadius: 10,
+});
+
+const mockText = (visible = true): Style => ({
+    style: {
+        fontFamily: 'Verdana',
+        fontSize: 12,
+        fontStyle: 'italic',
+        fontVariant: 'normal',
+        fontWeight: 100,
+        letterSpacing: 10,
+        lineHeight: 12,
+        textAlign: 'left',
+        textDecoration: 'none',
+        textTransform: 'uppercase',
+        verticalAlign: 'middle',
+    },
+    visible,
+    name: 'variable-name',
+    comment: '',
+    styleType: 'TEXT',
+    originalNode: { ...({} as StyleNode) },
+});
+
+describe('style output as css', () => {
+    let writeFileSync;
+
+    beforeEach(() => {
+        writeFileSync = sinon.stub(fs, 'writeFileSync');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should not print anything if style is not visible', async () => {
+        await outputter({
+            output: 'output-folder',
+        })([
+            mockFill([
+                mockSolid('solid-1'),
+            ], false),
+        ]);
+
+        expect(writeFileSync).to.be.calledOnce;
+        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.css', '');
+    });
+
+    it('should be able to change the filename, the extension and output folder', async () => {
+        await outputter({
+            output: 'output-folder',
+            getFilename: () => '_figma-styles',
+        })([]);
+
+        expect(writeFileSync).to.be.calledOnce;
+        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_figma-styles.css');
+    });
+
+    describe('colors', () => {
+        it('should not print anything if fill is not visible', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockFill([
+                    mockSolid('solid-1', false),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.css', '');
+        });
+
+        it('should be able to extract a solid color', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockFill([
+                    mockSolid('rgba(solid-1)', true),
+                    mockSolid('rgba(solid-2)', false),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n'
+                + ':root {\n\n'
+                + '/**\n'
+                + ' * lorem ipsum\n'
+                + ' */\n'
+                + '--variable-name: rgba(solid-1);\n'
+                + '\n}\n',
+            );
+        });
+
+        it('should be able to extract a linear gradient', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockFill([
+                    mockGradientLinear('linear-gradient-1'),
+                    mockGradientLinear('linear-gradient-2'),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n'
+                + ':root {\n\n'
+                + '/**\n'
+                + ' * lorem ipsum\n'
+                + ' */\n'
+                + '--variable-name: linear-gradient-1, linear-gradient-2;\n'
+                + '\n}\n',
+            );
+        });
+    });
+
+    describe('effects', () => {
+        it('should not print anything if effect is not visible', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockEffect([
+                    mockShadow('shadow-effect-1', false),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.css', '');
+        });
+
+        it('should be able to extract a box-shadow', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockEffect([
+                    mockShadow('shadow-effect-1'),
+                    mockShadow('shadow-effect-2'),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n'
+                + ':root {\n\n'
+                + '/**\n'
+                + ' * \n'
+                + ' */\n'
+                + '--variable-name: shadow-effect-1, shadow-effect-2;\n'
+                + '\n}\n',
+            );
+        });
+
+        it('should be able to extract a filter: blur()', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockEffect([
+                    mockBlur('blur-effect'),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWithMatch(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n'
+                + ':root {\n\n'
+                + '/**\n'
+                + ' * \n'
+                + ' */\n'
+                + '--variable-name: blur-effect;\n'
+                + '\n}\n',
+            );
+        });
+
+        it('should not combine shadow and blur effects', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockEffect([
+                    mockShadow('shadow-effect-1'),
+                    mockBlur('blur-effect-1'),
+                    mockShadow('shadow-effect-2'),
+                ]),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWith(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n'
+                + ':root {\n\n'
+                + '/**\n'
+                + ' * \n'
+                + ' */\n'
+                + '--variable-name: shadow-effect-1, shadow-effect-2;\n'
+                + '\n}\n',
+            );
+        });
+    });
+
+    describe('texts', () => {
+        it('should be able to extract a text', async () => {
+            await outputter({
+                output: 'output-folder',
+            })([
+                mockText(),
+            ]);
+
+            expect(writeFileSync).to.be.calledOnce;
+            expect(writeFileSync).to.be.calledWith(
+                sinon.match.any,
+
+                // eslint-disable-next-line indent
+                  '\n'
+                + ':root {\n\n'
+                + '/**\n'
+                + ' * \n'
+                + ' */\n'
+                + '--variable-name-font-family: "Verdana";\n'
+                + '--variable-name-font-size: 12px;\n'
+                + '--variable-name-font-style: italic;\n'
+                + '--variable-name-font-variant: normal;\n'
+                + '--variable-name-font-weight: 100;\n'
+                + '--variable-name-letter-spacing: 10px;\n'
+                + '--variable-name-line-height: 12px;\n'
+                + '--variable-name-text-align: left;\n'
+                + '--variable-name-text-decoration: none;\n'
+                + '--variable-name-text-transform: uppercase;\n'
+                + '--variable-name-vertical-align: middle;\n'
+                + '\n}\n',
+            );
+        });
+    });
+});

--- a/packages/output-styles-as-css/src/index.ts
+++ b/packages/output-styles-as-css/src/index.ts
@@ -1,0 +1,89 @@
+import * as FigmaExport from '@figma-export/types';
+import { writeVariable, writeComment, sanitizeText } from './utils';
+
+import fs = require('fs');
+import path = require('path');
+import makeDir = require('make-dir');
+
+type Options = {
+    output: string;
+    getFilename?: () => string;
+}
+
+export = ({
+    output,
+    getFilename = () => '_variables',
+}: Options): FigmaExport.StyleOutputter => {
+    return async (styles) => {
+        let text = '';
+
+        styles.forEach((style) => {
+            if (style.visible) {
+                // eslint-disable-next-line default-case
+                switch (style.styleType) {
+                    case 'FILL': {
+                        const value = style.fills
+                            .filter((fill) => fill.visible)
+                            .map((fill) => fill.value)
+                            .join(', ');
+
+                        if (value) {
+                            text += writeComment(style.comment);
+                            text += writeVariable(style.name, value);
+                        }
+
+                        break;
+                    }
+
+                    case 'EFFECT': {
+                        const visibleEffects = style.effects.filter((effect) => effect.visible);
+
+                        const boxShadowValue = visibleEffects
+                            .filter((effect) => effect.type === 'INNER_SHADOW' || effect.type === 'DROP_SHADOW')
+                            .map((effect) => effect.value)
+                            .join(', ');
+
+                        const filterBlurValue = visibleEffects
+                            .filter((effect) => effect.type === 'LAYER_BLUR')
+                            .map((effect) => effect.value)
+                            .join(', ');
+
+                        // Shadow and Blur effects cannot be combined together since they use two different CSS properties.
+                        const value = boxShadowValue || filterBlurValue;
+
+                        if (value) {
+                            text += writeComment(style.comment);
+                            text += writeVariable(style.name, value);
+                        }
+
+                        break;
+                    }
+
+                    case 'TEXT': {
+                        text += writeComment(style.comment);
+                        text += writeVariable(`${style.name}-font-family`, `"${style.style.fontFamily}"`);
+                        text += writeVariable(`${style.name}-font-size`, `${style.style.fontSize}px`);
+                        text += writeVariable(`${style.name}-font-style`, `${style.style.fontStyle}`);
+                        text += writeVariable(`${style.name}-font-variant`, `${style.style.fontVariant}`);
+                        text += writeVariable(`${style.name}-font-weight`, `${style.style.fontWeight}`);
+                        text += writeVariable(`${style.name}-letter-spacing`, `${style.style.letterSpacing}px`);
+                        text += writeVariable(`${style.name}-line-height`, `${style.style.lineHeight}px`);
+                        text += writeVariable(`${style.name}-text-align`, `${style.style.textAlign}`);
+                        text += writeVariable(`${style.name}-text-decoration`, `${style.style.textDecoration}`);
+                        text += writeVariable(`${style.name}-text-transform`, `${style.style.textTransform}`);
+                        text += writeVariable(`${style.name}-vertical-align`, `${style.style.verticalAlign}`);
+
+                        break;
+                    }
+                }
+            }
+        });
+
+        const filePath = makeDir.sync(path.resolve(output));
+        fs.writeFileSync(path.resolve(filePath, `${getFilename()}.css`), sanitizeText(`
+            :root {
+                ${text}
+            }
+        `));
+    };
+};

--- a/packages/output-styles-as-css/src/utils.test.ts
+++ b/packages/output-styles-as-css/src/utils.test.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+
+import { writeComment, writeVariable } from './utils';
+
+describe('utils', () => {
+    describe('writeComment', () => {
+        it('should write a proper comment', () => {
+            const text = writeComment('This is a comment');
+
+            expect(text).to.eql(
+                // eslint-disable-next-line indent
+                    '\n'
+                + '/**\n'
+                + ' * This is a comment\n'
+                + ' */\n',
+            );
+        });
+
+        it('should be able to print-out a comment in multiline', () => {
+            const text = writeComment('This is a comment\nin two lines');
+
+            expect(text).to.eql(
+                // eslint-disable-next-line indent
+                    '\n'
+                + '/**\n'
+                + ' * This is a comment\n'
+                + ' * in two lines\n'
+                + ' */\n',
+            );
+        });
+    });
+
+    describe('writeVariable', () => {
+        it('should return empty string is the value is empty', () => {
+            const text = writeVariable('variable-name', '');
+            expect(text).to.eql('');
+        });
+
+        it('should be able to print-out simple variable', () => {
+            const text = writeVariable('variable-name', '#fff');
+            expect(text).to.eql('--variable-name: #fff;\n');
+        });
+    });
+});

--- a/packages/output-styles-as-css/src/utils.ts
+++ b/packages/output-styles-as-css/src/utils.ts
@@ -1,0 +1,18 @@
+export const sanitizeText = (text: string): string => {
+    return text
+        .replace(/^[^\S\r\n]+/gm, '')
+        .replace(/^\*/gm, ' *')
+        .replace(/^"/gm, '  "');
+};
+
+export const writeComment = (message: string): string => {
+    return sanitizeText(`
+        /**
+         * ${message.replace(/\*\//g, '').split('\n').join('\n  * ')}
+         */
+    `);
+};
+
+export const writeVariable = (name: string, value: string): string => {
+    return value && sanitizeText(`--${name}: ${value};\n`);
+};

--- a/packages/output-styles-as-css/tsconfig.json
+++ b/packages/output-styles-as-css/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../types"},
+  ]
+}

--- a/packages/website/.eslintrc.js
+++ b/packages/website/.eslintrc.js
@@ -4,6 +4,8 @@ module.exports = {
         'eslint-config-developit'
     ],
     rules: {
-        indent: ['error', 4]
+        indent: ['error', 4],
+        'max-len': ['error', 160],
+        'react/jsx-indent-props': [2, 4]
     }
 };

--- a/packages/website/.eslintrc.js
+++ b/packages/website/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     ],
     rules: {
         indent: ['error', 4],
-        'max-len': ['error', 160],
-        'react/jsx-indent-props': [2, 4]
+        'react/jsx-indent-props': ['error', 4],
+        'max-len': ['error', 160]
     }
 };

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -30,6 +30,9 @@
     <body>
         <div id="root"></div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/prism.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/components/prism-less.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/components/prism-sass.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/plugins/normalize-whitespace/prism-normalize-whitespace.min.js"></script>
         <script src="./src/index.js"></script>
     </body>
 </html>

--- a/packages/website/scss/index.scss
+++ b/packages/website/scss/index.scss
@@ -48,12 +48,16 @@ pre[class*=language-] {
     line-height: 1.8em;
 }
 
+:not(pre)>code[class*=language-], pre[class*=language-] {
+    background-color: transparent;
+}
+
 .figma-gradient {
     background: $color-1;
     background: linear-gradient(90deg, $color-1 0%, $color-2 33%, $color-3 66%, $color-4 100%), rgba(255, 255, 255, 0.9);
     line-height: 2em;
 
-    @at-root code {
+    @at-root code:not([class*=language-]) {
         padding: 5px;
         margin: 0 2px;
         border-radius: 3px;
@@ -239,12 +243,18 @@ h2 {
             line-height: 2em;
             margin: 0.5em 0;
         }
+
+        pre[class*=language-] {
+            padding: 0;
+            display: inline-block;
+            max-width: 100%;
+        }
     }
 
     > div {
         flex: 0 1 45%;
         text-align: center;
-        
+        overflow: hidden;
         &.code-block--code {
             flex: 0 1 55%;
         }

--- a/packages/website/src/Code.js
+++ b/packages/website/src/Code.js
@@ -1,0 +1,12 @@
+const Code = ({
+    language,
+    code,
+    className,
+    indent = 4
+}) => (
+    <pre className={className}>
+        <code className={`language-${language}`}>{code.replace(/[ ]{4}/g, Array(indent).fill(' ').join(''))}</code>
+    </pre>
+);
+
+export default Code;

--- a/packages/website/src/CodeBlock.js
+++ b/packages/website/src/CodeBlock.js
@@ -1,3 +1,5 @@
+import Code from './Code';
+
 const CodeBlock = ({
     title,
     description,
@@ -11,7 +13,7 @@ const CodeBlock = ({
             {children}
         </div>
         <div class="code-block--code">
-            <pre className="figma-gradient with-opacity-05"><code className="language-js">{ code }</code></pre>
+            <Code language="js" code={code} className="figma-gradient with-opacity-05" />
         </div>
     </div>
 );

--- a/packages/website/src/output-components/ComponentsAsES6_base64.js
+++ b/packages/website/src/output-components/ComponentsAsES6_base64.js
@@ -21,21 +21,22 @@ const props = {
             Data URL <code>data:image/svg+xml;base64,</code>
         </Fragment>
     ),
-    code: `\
-module.exports = {
-    commands: [
-        ['components', {
-            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['icons', 'monochrome'],
-            outputters: [
-                require('@figma-export/output-components-as-es6')({
-                    output: './output/es6-base64',
-                    useBase64: true,
-                })
+    code: `
+        module.exports = {
+            commands: [
+                ['components', {
+                    fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+                    onlyFromPages: ['icons', 'monochrome'],
+                    outputters: [
+                        require('@figma-export/output-components-as-es6')({
+                            output: './output/es6-base64',
+                            useBase64: true,
+                        })
+                    ]
+                }]
             ]
-        }]
-    ]
-}`
+        }
+`
 };
 
 const Icon = ({ svg }) => (

--- a/packages/website/src/output-components/ComponentsAsES6_dataUrl.js
+++ b/packages/website/src/output-components/ComponentsAsES6_dataUrl.js
@@ -16,24 +16,27 @@ const props = {
     ),
     description: (
         <Fragment>
-            The .js file contains all components as Data URL so you can easly put this value into the src of your images. <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/probably-dont-base64-svg/">This is the best way</a> to load an svg as image.
+            The .js file contains all components as Data URL so you can easly put this value into
+            the src of your images. <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/probably-dont-base64-svg/">
+                This is the best way</a> to load an svg as image.
         </Fragment>
     ),
-    code: `\
-module.exports = {
-    commands: [
-        ['components', {
-            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['icons', 'monochrome'],
-            outputters: [
-                require('@figma-export/output-components-as-es6')({
-                    output: './output/es6-dataurl',
-                    useDataUrl: true,
-                })
+    code: `
+        module.exports = {
+            commands: [
+                ['components', {
+                    fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+                    onlyFromPages: ['icons', 'monochrome'],
+                    outputters: [
+                        require('@figma-export/output-components-as-es6')({
+                            output: './output/es6-dataurl',
+                            useDataUrl: true,
+                        })
+                    ]
+                }]
             ]
-        }]
-    ]
-}`
+        }
+`
 };
 
 const SvgAsES6ComponentDataUrl = () => (

--- a/packages/website/src/output-components/ComponentsAsSvgr_default.js
+++ b/packages/website/src/output-components/ComponentsAsSvgr_default.js
@@ -25,20 +25,21 @@ const props = {
             <code>import {`{ Squirrel }`} from './output/octicons-by-github';</code>
         </Fragment>
     ),
-    code: `\
-module.exports = {
-    commands: [
-        ['components', {
-            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['octicons-by-github'],
-            outputters: [
-                require('@figma-export/output-components-as-svgr')({
-                    output: './output'
-                })
+    code: `
+        module.exports = {
+            commands: [
+                ['components', {
+                    fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+                    onlyFromPages: ['octicons-by-github'],
+                    outputters: [
+                        require('@figma-export/output-components-as-svgr')({
+                            output: './output'
+                        })
+                    ]
+                }]
             ]
-        }]
-    ]
-}`
+        }
+`
 };
 
 const ComponentsAsSvgrDefault = () => (

--- a/packages/website/src/output-components/ComponentsAsSvgstore.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore.js
@@ -5,8 +5,11 @@ const ComponentsAsSvgstore = () => (
     <div class="section-block container text-center">
         <h3 id="svg-sprites"><code class="figma-gradient with-opacity-10">SVG Sprites</code></h3>
         <div>
-            Probably you already know what <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/css-sprites/">CSS Sprites</a> are, basically you can combine multiple images into a single image file and use it on a website.
-            SVG Sprites are very similar, but you will use .svg instead of .png. Discover more on this article "<a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/svg-sprites-use-better-icon-fonts/">Icon System with SVG Sprites</a>" where you will also find how to use this technique.
+            Probably you already know what <a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/css-sprites/">CSS Sprites</a> are,
+            basically you can combine multiple images into a single image file and use it on a website.
+            SVG Sprites are very similar, but you will use .svg instead of .png. Discover more on this article
+            "<a target="_blank" rel="noopener noreferrer" href="https://css-tricks.com/svg-sprites-use-better-icon-fonts/">Icon System with SVG Sprites</a>"
+            where you will also find how to use this technique.
         </div>
         <ComponentsAsSvgstoreDefault />
         <ComponentsAsSvgstoreMonochrome />

--- a/packages/website/src/output-components/ComponentsAsSvgstore_default.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore_default.js
@@ -21,20 +21,21 @@ const props = {
             <code>&lt;svg&gt;&lt;use href="#icon-name" /&gt;&lt;/svg&gt;</code>
         </Fragment>
     ),
-    code: `\
-module.exports = {
-    commands: [
-        ['components', {
-            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['icons', 'monochrome'],
-            outputters: [
-                require('@figma-export/output-components-as-svgstore')({
-                    output: './output/svgstore'
-                })
+    code: `
+        module.exports = {
+            commands: [
+                ['components', {
+                    fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+                    onlyFromPages: ['icons', 'monochrome'],
+                    outputters: [
+                        require('@figma-export/output-components-as-svgstore')({
+                            output: './output/svgstore'
+                        })
+                    ]
+                }]
             ]
-        }]
-    ]
-}`
+        }
+`
 };
 
 const SvgAsSvgstoreComponent = () => (

--- a/packages/website/src/output-components/ComponentsAsSvgstore_monochrome.js
+++ b/packages/website/src/output-components/ComponentsAsSvgstore_monochrome.js
@@ -19,23 +19,24 @@ const props = {
             properties are removed from the svg so you can easily customize the icon color from css.
         </Fragment>
     ),
-    code: `\
-module.exports = {
-    commands: [
-        ['components', {
-            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            onlyFromPages: ['icons'],
-            outputters: [
-                require('@figma-export/output-components-as-svgstore')({
-                    output: './output/svgstore-monochrome',
-                    svgstoreConfig: {
-                        cleanSymbols: ['fill']
-                    }
-                })
+    code: `
+        module.exports = {
+            commands: [
+                ['components', {
+                    fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+                    onlyFromPages: ['icons'],
+                    outputters: [
+                        require('@figma-export/output-components-as-svgstore')({
+                            output: './output/svgstore-monochrome',
+                            svgstoreConfig: {
+                                cleanSymbols: ['fill']
+                            }
+                        })
+                    ]
+                }]
             ]
-        }]
-    ]
-}`
+        }
+`
 };
 
 const SvgAsSvgstoreMonochromeComponent = () => (

--- a/packages/website/src/output-styles/AsCss.js
+++ b/packages/website/src/output-styles/AsCss.js
@@ -1,0 +1,45 @@
+import { Fragment } from 'preact';
+import Code from '../Code';
+import CodeBlock from '../CodeBlock';
+
+const props = {
+    title: (
+        <Fragment>
+            Export your styles as <code class="figma-gradient with-opacity-10">CSS Variables</code>
+        </Fragment>
+    ),
+    description: (
+        <Fragment>
+            <div>Once exported, you can easly use them directly into your <code>css</code> file.</div>
+            <Code language="css" indent={2} code={`
+                    body {
+                        color: var(--color-3);
+                        background: var(--color-linear-gradient);
+                        font-family: var(--regular-test-font-family);
+                        font-size: var(--regular-test-font-size);
+                    }
+                `}
+            />
+        </Fragment>
+    ),
+    code: `
+        module.exports = {
+            commands: [
+                ['styles', {
+                    fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+                    outputters: [
+                        require('@figma-export/output-styles-as-css')({
+                            output: './output/css',
+                        })
+                    ]
+                }]
+            ]
+        }
+    `
+};
+
+const AsCss = () => (
+    <CodeBlock {...props} />
+);
+
+export default AsCss;

--- a/packages/website/src/output-styles/AsLess.js
+++ b/packages/website/src/output-styles/AsLess.js
@@ -1,4 +1,5 @@
 import { Fragment } from 'preact';
+import Code from '../Code';
 import CodeBlock from '../CodeBlock';
 
 const props = {
@@ -9,24 +10,36 @@ const props = {
     ),
     description: (
         <Fragment>
-            {/* The .js file contains all components with Base 64 encoding.
-            If you want to use it into your images you need to prepend the
-            Data URL <code>data:image/svg+xml;base64,</code> */}
+            <div>
+                Once exported, you can import the generated <code>_variables.less</code> and use it.<br />
+                It contains <a href="http://lesscss.org/#variables">variables</a> and&nbsp;
+                <a href="http://lesscss.org/#maps">maps</a>.
+            </div>
+            <Code language="less" indent={2} code={`
+                    body {
+                        color: @color-3;
+                        background: @color-linear-gradient;
+                        font-family: #regular-text[font-family];
+                        font-size: #regular-text[font-size];
+                    }
+                `}
+            />
         </Fragment>
     ),
-    code: `\
-module.exports = {
-    commands: [
-        ['styles', {
-            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            outputters: [
-                require('@figma-export/output-styles-as-less')({
-                    output: './output/less',
-                })
+    code: `
+        module.exports = {
+            commands: [
+                ['styles', {
+                    fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+                    outputters: [
+                        require('@figma-export/output-styles-as-less')({
+                            output: './output/less',
+                        })
+                    ]
+                }]
             ]
-        }]
-    ]
-}`
+        }
+`
 };
 
 const AsLess = () => (

--- a/packages/website/src/output-styles/AsSass.js
+++ b/packages/website/src/output-styles/AsSass.js
@@ -1,36 +1,50 @@
 import { Fragment } from 'preact';
+import Code from '../Code';
 import CodeBlock from '../CodeBlock';
 
 const props = {
     title: (
         <Fragment>
-            Export your styles as <code class="figma-gradient with-opacity-10">SASS</code> and <code class="figma-gradient with-opacity-10">SCSS</code>
+            Export your styles
+            as <code class="figma-gradient with-opacity-10">SASS</code> and <code class="figma-gradient with-opacity-10">SCSS</code>
         </Fragment>
     ),
     description: (
         <Fragment>
-            {/* The .js file contains all components with Base 64 encoding.
-            If you want to use it into your images you need to prepend the
-            Data URL <code>data:image/svg+xml;base64,</code> */}
+            <div>
+                Once exported, you can import the generated <code>_variables.scss</code> and use it.<br />
+                It contains <a href="https://sass-lang.com/documentation/variables">variables</a> and&nbsp;
+                <a href="https://sass-lang.com/documentation/modules/map">maps</a>.
+            </div>
+            <Code language="sass" indent={2} code={`
+                    body {
+                        color: $color-3;
+                        background: $color-linear-gradient;
+                        font-family: map-get($regular-text, "font-family");
+                        font-size: map-get($regular-text, "font-size");
+                    }
+                `}
+            />
         </Fragment>
     ),
-    code: `\
-module.exports = {
-    commands: [
-        ['styles', {
-            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
-            outputters: [
-                require('@figma-export/output-styles-as-sass')({
-                    output: './output/scss',
-                }),
-                require('@figma-export/output-styles-as-sass')({
-                    output: './output/sass',
-                    getExtension: () => 'SASS',
-                })
+    code: `
+        module.exports = {
+            commands: [
+                ['styles', {
+                    fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
+                    outputters: [
+                        require('@figma-export/output-styles-as-sass')({
+                            output: './output/scss',
+                        }),
+                        require('@figma-export/output-styles-as-sass')({
+                            output: './output/sass',
+                            getExtension: () => 'SASS',
+                        })
+                    ]
+                }]
             ]
-        }]
-    ]
-}`
+        }
+`
 };
 
 const AsSass = () => (

--- a/packages/website/src/output-styles/FigmaStyles.js
+++ b/packages/website/src/output-styles/FigmaStyles.js
@@ -1,3 +1,4 @@
+import AsCss from './AsCss';
 import AsSass from './AsSass';
 import AsLess from './AsLess';
 
@@ -5,7 +6,12 @@ const FigmaStyles = () => (
     <div className="section-block container text-center">
         <div>
             You can export Figma Styles to different output.<br />
-            <a className="full" href="https://www.figma.com/file/RSzpKJcnb6uBRQ3rOfLIyUs5?node-id=119:2" rel="noreferrer noopener" target="_blank">https://www.figma.com/file/RSzpKJcnb6uBRQ3rOfLIyUs5?node-id=119:2</a><br />
+            <a
+                className="full"
+                href="https://www.figma.com/file/RSzpKJcnb6uBRQ3rOfLIyUs5?node-id=119:2"
+                rel="noreferrer noopener"
+                target="_blank"
+            >https://www.figma.com/file/RSzpKJcnb6uBRQ3rOfLIyUs5?node-id=119:2</a><br />
 
             <div className="feature-box">
                 <code className="figma-gradient text">Solid Colors</code>
@@ -47,6 +53,7 @@ const FigmaStyles = () => (
             </div>
         </div>
 
+        <AsCss />
         <AsSass />
         <AsLess />
     </div>


### PR DESCRIPTION
With this outputter you can export all the styles as variables inside a `.css` file.

This is a sample of the output:

```sh
$ tree output/
# output/
# └── _variables.css
```


## .figmaexportrc.js

You can easily add this outputter to your `.figmaexportrc.js`:

```js
module.exports = {
    commands: [
        ['styles', {
            fileId: 'RSzpKJcnb6uBRQ3rOfLIyUs5',
            outputters: [
                require('@figma-export/output-styles-as-css')({
                    output: './output'
                })
            ]
        }],
    ]
}
```

`output` is **mandatory**.

`getFilename` are **optional**.

```js
require('@figma-export/output-styles-as-css')({
    output: './output',
    getFilename: () => '_variables',
})
```

> *defaults may change, please refer to `./src/index.ts`*

Closes #70 