### PR TITLE
Handle Empty SVGs

### DIFF
--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -40,6 +40,8 @@ export const fetchAsSvgXml = (url: string): Promise<string> => {
             'Content-Type': 'images/svg+xml',
         },
     }).then((response) => {
+        if (response.data.length === 0) throw { message: 'Empty SVG File' };
+        
         return response.data;
     }).catch((error: Error) => {
         throw new Error(`while fetching svg "${url}": ${error.message}`);

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -40,8 +40,8 @@ export const fetchAsSvgXml = (url: string): Promise<string> => {
             'Content-Type': 'images/svg+xml',
         },
     }).then((response) => {
-        if (response.data.length === 0) throw { message: 'Empty SVG File' };
-        
+        if (response.data.length === 0) return '<svg></svg>';
+
         return response.data;
     }).catch((error: Error) => {
         throw new Error(`while fetching svg "${url}": ${error.message}`);


### PR DESCRIPTION
I have been having an issue where the Figma API is returning empty SVG files. I am not sure if this is a common problem or if there is a known solution. Either way, I submitted a ticket to Figma support for help on the issue.

In the meantime, I think that handling the invalid file earlier rather than later gives a much better debugging experience instead of having the parsing of the empty SVG file happen later on.

This PR handles such a case more gracefully.

This is my first time submitting code to this repo - not sure if each change is a separate version or if you bundle your changes together. Happy to do anything else needed! Thanks :)