### PR TITLE
Add 'getComponentFilename' property to output-components-as-svgr

### DIFF
--- a/packages/core/src/lib/_config.test.ts
+++ b/packages/core/src/lib/_config.test.ts
@@ -20,7 +20,7 @@ export const componentWithNumber = {
 export const componentWithSlashedName: Figma.Node = {
     ...({} as Figma.Component),
     id: '9:10',
-    name: 'icon/eye',
+    name: 'icon/Figma-logo',
     type: 'COMPONENT',
 };
 
@@ -30,7 +30,7 @@ export const componentWithSlashedNameOutput: FigmaExport.ComponentNode = {
     figmaExport: {
         id: '9:10',
         dirname: '.',
-        basename: 'icon/eye',
+        basename: 'icon/Figma-logo',
     },
 };
 

--- a/packages/output-components-as-svg/src/index.test.ts
+++ b/packages/output-components-as-svg/src/index.test.ts
@@ -39,7 +39,7 @@ describe('outputter as svg', () => {
         })(pages);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/eye.svg');
+        expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/Figma-logo.svg');
     });
 
     describe('options', () => {
@@ -55,7 +55,7 @@ describe('outputter as svg', () => {
             })(pages);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/fakePage-eye.svg');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/fakePage-Figma-logo.svg');
         });
 
         it('should be able to customize "dirname"', async () => {
@@ -68,7 +68,7 @@ describe('outputter as svg', () => {
             })(pages);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/icon/fakePage-eye.svg');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/icon/fakePage-Figma-logo.svg');
         });
     });
 });

--- a/packages/output-components-as-svgr/README.md
+++ b/packages/output-components-as-svgr/README.md
@@ -51,7 +51,7 @@ module.exports = {
 
 `output` is **mandatory**.
 
-`getDirname`, `getComponentName`, `getFileExtension`, `getExportTemplate` and `getSvgrConfig` are **optional**.
+`getDirname`, `getComponentName`, `getComponentFilename`, `getFileExtension`, `getExportTemplate` and `getSvgrConfig` are **optional**.
 
 ```js
 const path = require('path');
@@ -63,17 +63,20 @@ require('@figma-export/output-components-as-svgr')({
     output: './output',
     getDirname: (options) => `${options.pageName}${path.sep}${options.dirname}`,
     getComponentName: (options) => `${pascalCase(options.basename)}`,
+    getComponentFilename = (options): string => `${getComponentName(options)}`,
     getFileExtension: (options) => '.jsx',
     getSvgrConfig: (options) => ({}),
     getExportTemplate = (options): string => {
         const reactComponentName = getComponentName(options);
-        const reactComponentFilename = `${reactComponentName}${getFileExtension(options)}`;
+        const reactComponentFilename = `${getComponentFilename(options)}${getFileExtension(options)}`;
         return `export { default as ${reactComponentName} } from './${reactComponentFilename}';`;
     },
 })
 ```
 
 > *defaults may change, please refer to `./src/index.ts`*
+
+`getComponentFilename` if not set, it will use the same value for `getComponentName`.
 
 `getSvgrConfig` is a function that returns the [SVGR configuration](https://react-svgr.com/docs/options/) object.
 

--- a/packages/output-components-as-svgr/src/index.ts
+++ b/packages/output-components-as-svgr/src/index.ts
@@ -9,6 +9,7 @@ type Options = {
     output: string;
     getDirname?: (options: FigmaExport.ComponentOutputterParamOption) => string;
     getComponentName?: (options: FigmaExport.ComponentOutputterParamOption) => string;
+    getComponentFilename?: (options: FigmaExport.ComponentOutputterParamOption) => string;
     getFileExtension?: (options: FigmaExport.ComponentOutputterParamOption) => string;
     getExportTemplate?: (options: FigmaExport.ComponentOutputterParamOption) => string;
 
@@ -30,11 +31,12 @@ export = ({
     output,
     getDirname = (options): string => `${options.pageName}${path.sep}${options.dirname}`,
     getComponentName = (options): string => `${pascalCase(options.basename)}`,
+    getComponentFilename = (options): string => `${getComponentName(options)}`,
     getFileExtension = (): string => '.jsx',
     getSvgrConfig = (): Config => ({ }),
     getExportTemplate = (options): string => {
         const reactComponentName = getComponentName(options);
-        const reactComponentFilename = `${reactComponentName}${getFileExtension(options)}`;
+        const reactComponentFilename = `${getComponentFilename(options)}${getFileExtension(options)}`;
         return `export { default as ${reactComponentName} } from './${reactComponentFilename}';`;
     },
 }: Options): FigmaExport.ComponentOutputter => {
@@ -50,7 +52,7 @@ export = ({
                 };
 
                 const reactComponentName = getComponentName(options);
-                const reactComponentFilename = `${reactComponentName}${getFileExtension(options)}`;
+                const reactComponentFilename = `${getComponentFilename(options)}${getFileExtension(options)}`;
                 const filePath = path.resolve(output, getDirname(options));
 
                 fs.mkdirSync(filePath, { recursive: true });


### PR DESCRIPTION
```diff
require('@figma-export/output-components-as-svgr')({
    output: './output',
    getDirname: (options) => `${options.pageName}${path.sep}${options.dirname}`,
    getComponentName: (options) => `${pascalCase(options.basename)}`,
+   getComponentFilename = (options): string => `${getComponentName(options)}`,
    getFileExtension: (options) => '.jsx',
    getSvgrConfig: (options) => ({}),
    getExportTemplate = (options): string => {
        const reactComponentName = getComponentName(options);
        const reactComponentFilename = `${getComponentFilename(options)}${getFileExtension(options)}`;
        return `export { default as ${reactComponentName} } from './${reactComponentFilename}';`;
    },
})
```

linked to #121