### PR TITLE
Manage correctly a `pageName` with slashes (es6 and svgstore outputters)

### DIFF
--- a/packages/core/src/lib/_config.test.ts
+++ b/packages/core/src/lib/_config.test.ts
@@ -104,6 +104,17 @@ export const page1: Figma.Canvas = {
     ],
 };
 
+export const page1WithSlashes: Figma.Canvas = {
+    ...({} as Figma.Canvas),
+    id: '10:6',
+    name: 'page1/subpath/subsubpath',
+    type: 'CANVAS',
+    children: [
+        component1,
+        component2,
+    ],
+};
+
 export const page2: Figma.Canvas = {
     ...({} as Figma.Canvas),
     id: '10:7',

--- a/packages/output-components-as-es6/src/index.test.ts
+++ b/packages/output-components-as-es6/src/index.test.ts
@@ -149,6 +149,12 @@ describe('outputter as es6', () => {
             // eslint-disable-next-line max-len
             "export const figmaLogo = `data:image/svg+xml,%3csvg width='40' height='60' viewBox='0 0 40 60' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3c/svg%3e`;",
         );
+
+        expect(mkdirSync).to.be.calledOnce;
+        expect(mkdirSync).to.be.calledWithMatch(
+            'output',
+            { recursive: true },
+        );
     });
 
     it('should throw an error if component starts with a number', async () => {

--- a/packages/output-components-as-es6/src/index.ts
+++ b/packages/output-components-as-es6/src/index.ts
@@ -21,7 +21,6 @@ export = ({
     useBase64 = false,
     useDataUrl = false,
 }: Options): FigmaExport.ComponentOutputter => {
-    fs.mkdirSync(output, { recursive: true });
     return async (pages): Promise<void> => {
         pages.forEach((page) => {
             const { name: pageName, components } = page;
@@ -64,6 +63,8 @@ export = ({
             });
 
             const filePath = path.resolve(output, `${pageName}.js`);
+
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
             fs.writeFileSync(filePath, jsCode);
         });
     };

--- a/packages/output-components-as-es6/src/index.ts
+++ b/packages/output-components-as-es6/src/index.ts
@@ -22,9 +22,7 @@ export = ({
     useDataUrl = false,
 }: Options): FigmaExport.ComponentOutputter => {
     return async (pages): Promise<void> => {
-        pages.forEach((page) => {
-            const { name: pageName, components } = page;
-
+        pages.forEach(({ name: pageName, components }) => {
             let jsCode = '';
 
             components.forEach((component) => {

--- a/packages/output-components-as-svgr/src/index.ts
+++ b/packages/output-components-as-svgr/src/index.ts
@@ -40,7 +40,6 @@ export = ({
         return `export { default as ${reactComponentName} } from './${reactComponentFilename}';`;
     },
 }: Options): FigmaExport.ComponentOutputter => {
-    fs.mkdirSync(output, { recursive: true });
     const indexFile: IndexFile = {};
     return async (pages): Promise<void> => {
         pages.forEach(({ name: pageName, components }) => {

--- a/packages/output-components-as-svgstore/src/index.test.ts
+++ b/packages/output-components-as-svgstore/src/index.test.ts
@@ -34,6 +34,12 @@ describe('outputter as svgstore', () => {
             'output/page1.svg',
             'id="page1/Figma-Logo"',
         );
+
+        expect(mkdirSync).to.be.calledOnce;
+        expect(mkdirSync).to.be.calledWithMatch(
+            'output',
+            { recursive: true },
+        );
     });
 
     it('should create folders and subfolders when pageName contains slashes', async () => {

--- a/packages/output-components-as-svgstore/src/index.ts
+++ b/packages/output-components-as-svgstore/src/index.ts
@@ -21,7 +21,6 @@ export = ({
     getIconId = (options): string => `${options.pageName}/${options.componentName}`,
     svgstoreConfig = {},
 }: Options): FigmaExport.ComponentOutputter => {
-    fs.mkdirSync(output, { recursive: true });
     return async (pages): Promise<void> => {
         pages.forEach(({ name: pageName, components }) => {
             const sprites = svgstore(svgstoreConfig);
@@ -37,6 +36,8 @@ export = ({
             });
 
             const filePath = path.resolve(output, `${pageName}.svg`);
+
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
             fs.writeFileSync(filePath, sprites.toString({}));
         });
     };


### PR DESCRIPTION
This will recursively create folders to keep consistency with other outputters like `svg` and `svgr` that are already working in that way.