### PR TITLE
Add 'filterComponent' option

### DIFF
--- a/packages/core/src/lib/export-components.ts
+++ b/packages/core/src/lib/export-components.ts
@@ -7,6 +7,7 @@ export const components: FigmaExport.ComponentsCommand = async ({
     fileId,
     version,
     onlyFromPages = [],
+    filterComponent = () => true,
     transformers = [],
     outputters = [],
     concurrency = 30,
@@ -27,7 +28,7 @@ export const components: FigmaExport.ComponentsCommand = async ({
         throw new Error('\'document\' is missing.');
     }
 
-    const pages = getPages((document), { only: onlyFromPages });
+    const pages = getPages((document), { only: onlyFromPages, filter: filterComponent });
 
     log('preparing components');
     const pagesWithSvg = await enrichPagesWithSvg(client, fileId, pages, {

--- a/packages/core/src/lib/figma.ts
+++ b/packages/core/src/lib/figma.ts
@@ -13,11 +13,14 @@ import {
     chunk,
 } from './utils';
 
-const getComponents = (children: readonly Figma.Node[] = []): FigmaExport.ComponentNode[] => {
+const getComponents = (
+    children: readonly Figma.Node[] = [],
+    filter: FigmaExport.ComponentFilter = () => true,
+): FigmaExport.ComponentNode[] => {
     let components: FigmaExport.ComponentNode[] = [];
 
     children.forEach((component) => {
-        if (component.type === 'COMPONENT') {
+        if (component.type === 'COMPONENT' && filter(component)) {
             components.push({
                 ...component,
                 svg: '',
@@ -33,7 +36,7 @@ const getComponents = (children: readonly Figma.Node[] = []): FigmaExport.Compon
         if ('children' in component) {
             components = [
                 ...components,
-                ...getComponents((component.children)),
+                ...getComponents((component.children), filter),
             ];
         }
     });
@@ -48,6 +51,7 @@ const filterPagesByName = (pages: readonly Figma.Canvas[], pageNames: string | s
 
 type GetPagesOptions = {
     only?: string | string[];
+    filter?: FigmaExport.ComponentFilter;
 }
 
 const getPages = (document: Figma.Document, options: GetPagesOptions = {}): FigmaExport.PageNode[] => {
@@ -56,7 +60,7 @@ const getPages = (document: Figma.Document, options: GetPagesOptions = {}): Figm
     return pages
         .map((page) => ({
             ...page,
-            components: getComponents(page.children as readonly FigmaExport.ComponentNode[]),
+            components: getComponents(page.children as readonly FigmaExport.ComponentNode[], options.filter),
         }))
         .filter((page) => page.components.length > 0);
 };

--- a/packages/types/src/commands.ts
+++ b/packages/types/src/commands.ts
@@ -1,4 +1,9 @@
-import { StringTransformer, ComponentOutputter, PageNode } from './global';
+import {
+    StringTransformer,
+    ComponentOutputter,
+    PageNode,
+    ComponentFilter,
+} from './global';
 import { StyleOutputter, Style } from './styles';
 
 export type BaseCommandOptions = {
@@ -25,6 +30,9 @@ export type ComponentsCommandOptions = {
 
     /** Figma page names (all pages when not specified) */
     onlyFromPages?: string[];
+
+    /** Filter components to export */
+    filterComponent?: ComponentFilter;
 
     /** Transformer module name or path */
     transformers?: StringTransformer[];

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -24,3 +24,5 @@ export type ComponentOutputterParamOption = {
 } & ComponentExtras;
 
 export type StyleNode = Figma.Style & Figma.Node
+
+export type ComponentFilter = (component: Figma.Component) => boolean


### PR DESCRIPTION
Now, figma-export only supports to filter components by page name.
This PR adds support to filter components by their properties like name, size, etc. 

For example
```javascript
// figmaexportrc.js

module.exports = {
  commands: [
    [
      'components',
      {
        fileId: 'your-file-id',
        filterComponent: (component) => !/^Guide/.test(component.name),
        transformers: [],
        outputters: [],
      },
    ],
  ],
};

```