### PR TITLE
Handle 'undefined' output from transformers

### DIFF
--- a/packages/core/src/lib/figma.ts
+++ b/packages/core/src/lib/figma.ts
@@ -11,6 +11,7 @@ import {
     promiseSequentially,
     fromEntries,
     chunk,
+    emptySvg,
 } from './utils';
 
 const getComponents = (
@@ -164,7 +165,7 @@ const enrichPagesWithSvg = async (
         ...page,
         components: page.components.map((component) => ({
             ...component,
-            svg: svgs[component.id],
+            svg: svgs[component.id] || emptySvg,
         })),
     }));
 };

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -2,6 +2,8 @@ import axios from 'axios';
 
 export const toArray = <T>(any: T): T[] => (Array.isArray(any) ? any : [any]);
 
+export const emptySvg = '<svg></svg>';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fromEntries = (iterable: any[][]): { [key: string]: any } => {
     return [...iterable].reduce((obj: { [key: string]: unknown }, [key, val]) => {
@@ -40,7 +42,7 @@ export const fetchAsSvgXml = (url: string): Promise<string> => {
             'Content-Type': 'images/svg+xml',
         },
     }).then((response) => {
-        if (response.data.length === 0) return '<svg></svg>';
+        if (response.data.length === 0) return emptySvg;
 
         return response.data;
     }).catch((error: Error) => {

--- a/packages/output-components-as-es6/src/index.test.ts
+++ b/packages/output-components-as-es6/src/index.test.ts
@@ -157,6 +157,29 @@ describe('outputter as es6', () => {
         );
     });
 
+    it('should not break when transformers return "undefined"', async () => {
+        const writeFileSync = sinon.stub(fs, 'writeFileSync');
+        const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
+        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages, {
+            transformers: [async () => undefined],
+        });
+
+        nockScope.done();
+
+        await outputter({
+            output: 'output',
+        })(pagesWithSvg);
+
+        expect(writeFileSync).to.be.calledOnce;
+        expect(writeFileSync).to.be.calledWithMatch(
+            'output/page1.js',
+
+            // eslint-disable-next-line max-len
+            'export const figmaLogo = `<svg></svg>`;',
+        );
+    });
+
     it('should throw an error if component starts with a number', async () => {
         const page = {
             ...figmaDocument.page1,


### PR DESCRIPTION
This fix solves the broken export when transformers return `undefined`

```ts
...

const componentOptions: ComponentsCommandOptions = {
    fileId: 'fzYhvQpqwhZDUImRz431Qo',
    onlyFromPages: ['icons'],
    transformers: [
        async () => undefined
    ],
    outputters: [
        outputComponentsAsEs6({
            output: './output'
        })
    ]
};
```