### PR TITLE
Fix tests on Windows

### DIFF
--- a/packages/output-components-as-es6/src/index.test.ts
+++ b/packages/output-components-as-es6/src/index.test.ts
@@ -12,6 +12,7 @@ import * as figmaDocument from '../../core/src/lib/_config.test';
 import * as figma from '../../core/src/lib/figma';
 
 import fs from 'fs';
+import path from 'path';
 import outputter from './index';
 
 describe('outputter as es6', () => {
@@ -80,7 +81,7 @@ describe('outputter as es6', () => {
 
         expect(writeFileSync).to.be.calledOnce;
         expect(writeFileSync).to.be.calledWithMatch(
-            'output/page1.js',
+            path.join('output', 'page1.js'),
 
             // eslint-disable-next-line max-len
             'export const figmaLogo = `<svg width="40" height="60" viewBox="0 0 40 60" fill="none" xmlns="http://www.w3.org/2000/svg"></svg>`;',
@@ -102,7 +103,7 @@ describe('outputter as es6', () => {
 
         expect(writeFileSync).to.be.calledOnce;
         expect(writeFileSync).to.be.calledWithMatch(
-            'output/page1.js',
+            path.join('output', 'page1.js'),
 
             // eslint-disable-next-line max-len
             'export const iFigmaLogoMyIco = `<svg width="40" height="60" viewBox="0 0 40 60" fill="none" xmlns="http://www.w3.org/2000/svg"></svg>`;',
@@ -124,7 +125,7 @@ describe('outputter as es6', () => {
 
         expect(writeFileSync).to.be.calledOnce;
         expect(writeFileSync).to.be.calledWithMatch(
-            'output/page1.js',
+            path.join('output', 'page1.js'),
             // eslint-disable-next-line max-len
             'export const figmaLogo = `PHN2ZyB3aWR0aD0iNDAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA0MCA2MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48L3N2Zz4=`;',
         );
@@ -145,7 +146,7 @@ describe('outputter as es6', () => {
 
         expect(writeFileSync).to.be.calledOnce;
         expect(writeFileSync).to.be.calledWithMatch(
-            'output/page1.js',
+            path.join('output', 'page1.js'),
             // eslint-disable-next-line max-len
             "export const figmaLogo = `data:image/svg+xml,%3csvg width='40' height='60' viewBox='0 0 40 60' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3c/svg%3e`;",
         );
@@ -173,7 +174,7 @@ describe('outputter as es6', () => {
 
         expect(writeFileSync).to.be.calledOnce;
         expect(writeFileSync).to.be.calledWithMatch(
-            'output/page1.js',
+            path.join('output', 'page1.js'),
 
             // eslint-disable-next-line max-len
             'export const figmaLogo = `<svg></svg>`;',
@@ -238,7 +239,7 @@ describe('outputter as es6', () => {
 
         expect(writeFileSync).to.be.calledOnce;
         expect(writeFileSync).to.be.calledWithMatch(
-            'output/page1/subpath/subsubpath.js',
+            path.join('output', 'page1', 'subpath', 'subsubpath.js'),
 
             // eslint-disable-next-line max-len
             'export const figmaLogo = `<svg width="40" height="60" viewBox="0 0 40 60" fill="none" xmlns="http://www.w3.org/2000/svg"></svg>`;',
@@ -246,7 +247,7 @@ describe('outputter as es6', () => {
 
         expect(mkdirSync).to.be.calledOnce;
         expect(mkdirSync).to.be.calledWithMatch(
-            'output/page1/subpath',
+            path.join('output', 'page1', 'subpath'),
             { recursive: true },
         );
     });

--- a/packages/output-components-as-svg/src/index.test.ts
+++ b/packages/output-components-as-svg/src/index.test.ts
@@ -4,6 +4,7 @@ import * as figmaDocument from '../../core/src/lib/_config.test';
 import * as figma from '../../core/src/lib/figma';
 
 import fs from 'fs';
+import path from 'path';
 import outputter from './index';
 
 describe('outputter as svg', () => {
@@ -25,8 +26,8 @@ describe('outputter as svg', () => {
         })(pages);
 
         expect(writeFileSync).to.be.calledTwice;
-        expect(writeFileSync.firstCall).to.be.calledWithMatch('output/page1/Figma-Logo.svg');
-        expect(writeFileSync.secondCall).to.be.calledWithMatch('output/page1/Search.svg');
+        expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'page1', 'Figma-Logo.svg'));
+        expect(writeFileSync.secondCall).to.be.calledWithMatch(path.join('output', 'page1', 'Search.svg'));
     });
 
     it('should create folder if component names contain slashes', async () => {
@@ -39,7 +40,7 @@ describe('outputter as svg', () => {
         })(pages);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/Figma-logo.svg');
+        expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'Figma-logo.svg'));
     });
 
     describe('options', () => {
@@ -55,7 +56,7 @@ describe('outputter as svg', () => {
             })(pages);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/fakePage-Figma-logo.svg');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'fakePage-Figma-logo.svg'));
         });
 
         it('should be able to customize "dirname"', async () => {
@@ -68,7 +69,7 @@ describe('outputter as svg', () => {
             })(pages);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/icon/fakePage-Figma-logo.svg');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'icon', 'fakePage-Figma-logo.svg'));
         });
     });
 });

--- a/packages/output-components-as-svgr/src/index.test.ts
+++ b/packages/output-components-as-svgr/src/index.test.ts
@@ -7,6 +7,7 @@ import * as figmaDocument from '../../core/src/lib/_config.test';
 import * as figma from '../../core/src/lib/figma';
 
 import fs from 'fs';
+import path from 'path';
 import outputter from './index';
 
 describe('outputter as svgr', () => {
@@ -62,10 +63,10 @@ describe('outputter as svgr', () => {
         })(pages);
 
         expect(writeFileSync).to.be.calledThrice;
-        expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/FigmaLogo.jsx');
-        expect(writeFileSync.secondCall).to.be.calledWithMatch('output/fakePage/Search.jsx');
+        expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'FigmaLogo.jsx'));
+        expect(writeFileSync.secondCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'Search.jsx'));
         expect(writeFileSync.thirdCall).to.be.calledWithMatch(
-            'output/fakePage/index.js',
+            path.join('output', 'fakePage', 'index.js'),
             'export { default as FigmaLogo } from \'./FigmaLogo.jsx\';',
         );
     });
@@ -80,10 +81,10 @@ describe('outputter as svgr', () => {
         })(pages);
 
         expect(writeFileSync).to.be.calledThrice;
-        expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/FigmaLogo.tsx');
-        expect(writeFileSync.secondCall).to.be.calledWithMatch('output/fakePage/Search.tsx');
+        expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'FigmaLogo.tsx'));
+        expect(writeFileSync.secondCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'Search.tsx'));
         expect(writeFileSync.thirdCall).to.be.calledWithMatch(
-            'output/fakePage/index.ts',
+            path.join('output', 'fakePage', 'index.ts'),
             'export { default as FigmaLogo } from \'./FigmaLogo.tsx\';',
         );
     });
@@ -98,9 +99,9 @@ describe('outputter as svgr', () => {
         })(pages);
 
         expect(writeFileSync).to.be.calledTwice;
-        expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/Search.jsx');
+        expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'Search.jsx'));
         expect(writeFileSync.secondCall).to.be.calledWithMatch(
-            'output/fakePage/index.js',
+            path.join('output', 'fakePage', 'index.js'),
             'export { Search } from \'./customPath\';',
         );
     });
@@ -114,8 +115,8 @@ describe('outputter as svgr', () => {
         })(pages);
 
         expect(writeFileSync).to.be.calledTwice;
-        expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/FigmaLogo.jsx');
-        expect(writeFileSync.secondCall).to.be.calledWithMatch('output/fakePage/icon/index.js');
+        expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'FigmaLogo.jsx'));
+        expect(writeFileSync.secondCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'index.js'));
     });
 
     describe('options', () => {
@@ -128,9 +129,9 @@ describe('outputter as svgr', () => {
                 getDirname: (options) => `${options.dirname}`,
             })(pages);
 
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/icon/FigmaLogo.jsx');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'icon', 'FigmaLogo.jsx'));
             expect(writeFileSync.secondCall).to.be.calledWithMatch(
-                'output/icon/index.js',
+                path.join('output', 'icon', 'index.js'),
                 "export { default as FigmaLogo } from './FigmaLogo.jsx';",
             );
         });
@@ -141,9 +142,9 @@ describe('outputter as svgr', () => {
                 getComponentName: (options) => options.basename.toUpperCase(),
             })(pages);
 
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/FIGMA-LOGO.jsx');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'FIGMA-LOGO.jsx'));
             expect(writeFileSync.secondCall).to.be.calledWithMatch(
-                'output/fakePage/icon/index.js',
+                path.join('output', 'fakePage', 'icon', 'index.js'),
                 "export { default as FIGMA-LOGO } from './FIGMA-LOGO.jsx';",
             );
         });
@@ -154,9 +155,9 @@ describe('outputter as svgr', () => {
                 getComponentFilename: (options) => kebabCase(options.basename).toLowerCase(),
             })(pages);
 
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/figma-logo.jsx');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'figma-logo.jsx'));
             expect(writeFileSync.secondCall).to.be.calledWithMatch(
-                'output/fakePage/icon/index.js',
+                path.join('output', 'fakePage', 'icon', 'index.js'),
                 "export { default as FigmaLogo } from './figma-logo.jsx';",
             );
         });
@@ -168,9 +169,9 @@ describe('outputter as svgr', () => {
                 getComponentFilename: (options) => camelCase(options.basename),
             })(pages);
 
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/figmaLogo.jsx');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'figmaLogo.jsx'));
             expect(writeFileSync.secondCall).to.be.calledWithMatch(
-                'output/fakePage/icon/index.js',
+                path.join('output', 'fakePage', 'icon', 'index.js'),
                 "export { default as FIGMA-LOGO } from './figmaLogo.jsx';",
             );
         });
@@ -181,8 +182,11 @@ describe('outputter as svgr', () => {
                 getFileExtension: () => '.js',
             })(pages);
 
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/FigmaLogo.js');
-            expect(writeFileSync.secondCall).to.be.calledWithMatch('output/fakePage/icon/index.js', "from './FigmaLogo.js';");
+            expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'FigmaLogo.js'));
+            expect(writeFileSync.secondCall).to.be.calledWithMatch(
+                path.join('output', 'fakePage', 'icon', 'index.js'),
+                "from './FigmaLogo.js';",
+            );
         });
 
         it('should be able to customize "svgrConfig"', async () => {
@@ -193,7 +197,7 @@ describe('outputter as svgr', () => {
                 getSvgrConfig: () => ({ native: true }),
             })(pagesWithSvg);
 
-            expect(writeFileSync.firstCall).to.be.calledWithMatch('output/fakePage/icon/FigmaLogo.jsx');
+            expect(writeFileSync.firstCall).to.be.calledWithMatch(path.join('output', 'fakePage', 'icon', 'FigmaLogo.jsx'));
             expect(svgrAsync.firstCall).to.be.calledWithMatch(figmaDocument.componentWithSlashedNameOutput.svg, { native: true });
         });
     });

--- a/packages/output-components-as-svgstore/src/index.test.ts
+++ b/packages/output-components-as-svgstore/src/index.test.ts
@@ -5,6 +5,7 @@ import * as figmaDocument from '../../core/src/lib/_config.test';
 import * as figma from '../../core/src/lib/figma';
 
 import fs from 'fs';
+import path from 'path';
 import outputter from './index';
 
 describe('outputter as svgstore', () => {
@@ -30,7 +31,7 @@ describe('outputter as svgstore', () => {
 
         expect(writeFileSync).to.be.calledOnce;
         expect(writeFileSync).to.be.calledWithMatch(
-            'output/page1.svg',
+            path.join('output', 'page1.svg'),
             'id="page1/Figma-Logo"',
         );
 
@@ -52,13 +53,13 @@ describe('outputter as svgstore', () => {
 
         expect(writeFileSync).to.be.calledOnce;
         expect(writeFileSync).to.be.calledWithMatch(
-            'output/page1/subpath/subsubpath.svg',
+            path.join('output', 'page1', 'subpath', 'subsubpath.svg'),
             'id="page1/subpath/subsubpath/Figma-Logo"',
         );
 
         expect(mkdirSync).to.be.calledOnce;
         expect(mkdirSync).to.be.calledWithMatch(
-            'output/page1/subpath',
+            path.join('output', 'page1', 'subpath'),
             { recursive: true },
         );
     });

--- a/packages/output-styles-as-css/src/index.test.ts
+++ b/packages/output-styles-as-css/src/index.test.ts
@@ -9,6 +9,7 @@ import {
 import { camelCase } from '@figma-export/utils';
 
 import fs from 'fs';
+import path from 'path';
 import outputter from './index';
 
 const mockFill = (fills: FillStyle[], { visible = true, name = 'variable/name', comment = 'lorem ipsum' } = {}): Style => ({
@@ -109,7 +110,7 @@ describe('style output as css', () => {
         ]);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.css', '');
+        expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_variables.css'), '');
     });
 
     it('should be able to change the filename, the extension and output folder', async () => {
@@ -119,7 +120,7 @@ describe('style output as css', () => {
         })([]);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_figma-styles.css');
+        expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_figma-styles.css'));
     });
 
     it('should sanitize variable names', async () => {
@@ -182,7 +183,7 @@ describe('style output as css', () => {
             ]);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.css', '');
+            expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_variables.css'), '');
         });
 
         it('should be able to extract a solid color', async () => {
@@ -247,7 +248,7 @@ describe('style output as css', () => {
             ]);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.css', '');
+            expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_variables.css'), '');
         });
 
         it('should be able to extract a box-shadow', async () => {

--- a/packages/output-styles-as-less/src/index.test.ts
+++ b/packages/output-styles-as-less/src/index.test.ts
@@ -9,6 +9,7 @@ import {
 import { camelCase } from '@figma-export/utils';
 
 import fs from 'fs';
+import path from 'path';
 import outputter from './index';
 
 const mockFill = (fills: FillStyle[], { visible = true, name = 'variable/name', comment = 'lorem ipsum' } = {}): Style => ({
@@ -109,7 +110,7 @@ describe('style output as less', () => {
         ]);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.less', '');
+        expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_variables.less'), '');
     });
 
     it('should be able to change the filename, the extension and output folder', async () => {
@@ -119,7 +120,7 @@ describe('style output as less', () => {
         })([]);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_figma-styles.less');
+        expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_figma-styles.less'));
     });
 
     it('should sanitize variable names', async () => {
@@ -178,7 +179,7 @@ describe('style output as less', () => {
             ]);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.less', '');
+            expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_variables.less'), '');
         });
 
         it('should be able to extract a solid color', async () => {

--- a/packages/output-styles-as-sass/src/index.test.ts
+++ b/packages/output-styles-as-sass/src/index.test.ts
@@ -9,6 +9,7 @@ import {
 import { camelCase } from '@figma-export/utils';
 
 import fs from 'fs';
+import path from 'path';
 import outputter from './index';
 
 const mockFill = (fills: FillStyle[], { visible = true, name = 'variable/name', comment = 'lorem ipsum' } = {}): Style => ({
@@ -109,7 +110,7 @@ describe('style output as scss', () => {
         ]);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.scss', '');
+        expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_variables.scss'), '');
     });
 
     it('should be able to change the filename, the extension and output folder', async () => {
@@ -120,7 +121,7 @@ describe('style output as scss', () => {
         })([]);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync).to.be.calledWithMatch('/output-folder/_figma-styles.sass');
+        expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_figma-styles.sass'));
     });
 
     it('should sanitize variable names', async () => {
@@ -179,7 +180,7 @@ describe('style output as scss', () => {
             ]);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync).to.be.calledWithMatch('/output-folder/_variables.scss', '');
+            expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', '_variables.scss'), '');
         });
 
         it('should be able to extract a solid color', async () => {

--- a/packages/output-styles-as-style-dictionary/src/index.test.ts
+++ b/packages/output-styles-as-style-dictionary/src/index.test.ts
@@ -9,6 +9,7 @@ import {
 import { camelCase } from '@figma-export/utils';
 
 import fs from 'fs';
+import path from 'path';
 import outputter from './index';
 
 const mockFill = (fills: FillStyle[], { visible = true, name = 'variable/name', comment = 'lorem ipsum' } = {}): Style => ({
@@ -109,7 +110,7 @@ describe('style output as style-dictionary json', () => {
         ]);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync).to.be.calledWithMatch('/output-folder/base.json', '');
+        expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', 'base.json'), '');
     });
 
     it('should be able to change the filename, the extension and output folder', async () => {
@@ -120,7 +121,7 @@ describe('style output as style-dictionary json', () => {
         })([]);
 
         expect(writeFileSync).to.be.calledOnce;
-        expect(writeFileSync).to.be.calledWithMatch('/output-folder/base-file.json');
+        expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', 'base-file.json'));
     });
 
     it('should sanitize variable names', async () => {
@@ -181,7 +182,7 @@ describe('style output as style-dictionary json', () => {
             ]);
 
             expect(writeFileSync).to.be.calledOnce;
-            expect(writeFileSync).to.be.calledWithMatch('/output-folder/base.json', '');
+            expect(writeFileSync).to.be.calledWithMatch(path.join('output-folder', 'base.json'), '');
         });
 
         it('should be able to extract a solid color', async () => {


### PR DESCRIPTION
This pull request changes tests with hardcoded path separators to use `path.join()` instead in order to solve test failures that are caused by path separator mismatch.