### PR TITLE
Add support for exporting by node ID-s

### DIFF
--- a/packages/cli/src/commands/components.ts
+++ b/packages/cli/src/commands/components.ts
@@ -15,6 +15,7 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
     .option('-r, --retries', 'Maximum number of retries when fetching fails', 3)
     .option('-o, --output', 'Output directory', 'output')
     .option('-p, --page', 'Figma page names (all pages when not specified)')
+    .option('-i, --ids', 'Figma node ID-s (cannot be used together with --page)')
     .option('--fileVersion', `A specific version ID to get. Omitting this will get the current version of the file.
                          https://help.figma.com/hc/en-us/articles/360038006754-View-a-file-s-version-history`)
     .example('components fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-components-as-svg')
@@ -29,6 +30,7 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
             const outputter = asArray<string>(opts.outputter);
             const transformer = asArray<string>(opts.transformer);
             const page = asArray<string>(opts.page);
+            const ids = asArray<string>(opts.ids);
 
             spinner.info(`Exporting ${fileId} with [${transformer.join(', ')}] as [${outputter.join(', ')}]`);
 
@@ -41,6 +43,7 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
                 retries,
                 token: process.env.FIGMA_TOKEN || '',
                 onlyFromPages: page,
+                ids,
                 transformers: requirePackages<FigmaExport.StringTransformer>(transformer),
                 outputters: requirePackages<FigmaExport.ComponentOutputter>(outputter, { output }),
 

--- a/packages/cli/src/commands/styles.ts
+++ b/packages/cli/src/commands/styles.ts
@@ -12,6 +12,7 @@ export const addStyles = (prog: Sade, spinner: Ora) => prog
     .option('-O, --outputter', 'Outputter module or path')
     .option('-o, --output', 'Output directory', 'output')
     .option('-p, --page', 'Figma page names (all pages when not specified)')
+    .option('-i, --ids', 'Figma node ID-s (cannot be used together with --page)')
     .option('--fileVersion', `A specific version ID to get. Omitting this will get the current version of the file.
                          https://help.figma.com/hc/en-us/articles/360038006754-View-a-file-s-version-history`)
     .example('styles fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-styles-as-css')
@@ -23,6 +24,7 @@ export const addStyles = (prog: Sade, spinner: Ora) => prog
         }) => {
             const outputter = asArray<string>(opts.outputter);
             const page = asArray<string>(opts.page);
+            const ids = asArray<string>(opts.ids);
 
             spinner.info(`Exporting ${fileId} as [${outputter.join(', ')}]`);
 
@@ -33,6 +35,7 @@ export const addStyles = (prog: Sade, spinner: Ora) => prog
                 version: fileVersion,
                 token: process.env.FIGMA_TOKEN || '',
                 onlyFromPages: page,
+                ids,
                 outputters: requirePackages<FigmaExport.StyleOutputter>(outputter, { output }),
 
                 // eslint-disable-next-line no-param-reassign

--- a/packages/core/src/lib/export-components.ts
+++ b/packages/core/src/lib/export-components.ts
@@ -1,12 +1,17 @@
 import * as FigmaExport from '@figma-export/types';
 
-import { getClient, getPages, enrichPagesWithSvg } from './figma';
+import {
+    getClient, getPageIds, enrichNodesWithSvg, getComponents,
+} from './figma';
+
+import { notEmpty } from './utils';
 
 export const components: FigmaExport.ComponentsCommand = async ({
     token,
     fileId,
     version,
     onlyFromPages = [],
+    ids = [],
     filterComponent = () => true,
     transformers = [],
     outputters = [],
@@ -17,10 +22,16 @@ export const components: FigmaExport.ComponentsCommand = async ({
         console.log(msg);
     },
 }) => {
+    if (onlyFromPages?.length && ids?.length) {
+        throw new Error('\'onlyFromPages\' and \'ids\' are mutually exclusive.');
+    }
+
     const client = getClient(token);
 
     log('fetching document');
-    const { data: { document = null } = {} } = await client.file(fileId, { version }).catch((error: Error) => {
+    const {
+        data: { document = null, version: documentVersion } = {},
+    } = await client.file(fileId, { version, depth: 1 }).catch((error: Error) => {
         throw new Error(`while fetching file "${fileId}${version ? `?version=${version}` : ''}": ${error.message}`);
     });
 
@@ -28,17 +39,31 @@ export const components: FigmaExport.ComponentsCommand = async ({
         throw new Error('\'document\' is missing.');
     }
 
-    const pages = getPages((document), { only: onlyFromPages, filter: filterComponent });
+    const rootNodeIds = ids?.length ? ids : getPageIds(document, onlyFromPages);
+
+    const { data: fileNodesResponse } = await client.fileNodes(fileId, { ids: rootNodeIds, version: documentVersion });
+
+    const rootNodes = Object.values(fileNodesResponse.nodes)
+        .filter(notEmpty)
+        .map((node): FigmaExport.PageNode => ({
+            ...node.document,
+            components: getComponents(node.document, filterComponent),
+        }))
+        .filter((page) => page.components.length > 0);
+
+    if (!rootNodes) {
+        throw new Error('nodes list is empty');
+    }
 
     log('preparing components');
-    const pagesWithSvg = await enrichPagesWithSvg(client, fileId, pages, {
+    const pagesWithSvg = await enrichNodesWithSvg(client, fileId, rootNodes, {
         transformers,
         concurrency,
         retries,
         onFetchCompleted: ({ index, total }) => {
             log(`fetching components ${index}/${total}`);
         },
-    });
+    }, documentVersion);
 
     await Promise.all(outputters.map((outputter) => outputter(pagesWithSvg)));
 

--- a/packages/core/src/lib/figmaStyles/index.ts
+++ b/packages/core/src/lib/figmaStyles/index.ts
@@ -26,12 +26,13 @@ const fetchStyles = async (
         throw new Error(`while fetching fileNodes: ${error.message}`);
     });
 
-    const styleNodes = Object.values(nodes).map((node) => node?.document);
-
-    return styleNodes.map((node) => ({
-        ...(node ? styles[node.id] : ({} as Figma.Style)),
-        ...(node as Figma.Node),
-    }));
+    return Object.values(nodes)
+        .filter(notEmpty)
+        .map((node) => node.document)
+        .map((node) => ({
+            ...styles[node.id],
+            ...node,
+        }));
 };
 
 const parseStyles = (styleNodes: FigmaExport.StyleNode[]): FigmaExport.Style[] => {

--- a/packages/types/src/commands.ts
+++ b/packages/types/src/commands.ts
@@ -45,6 +45,8 @@ export type ComponentsCommandOptions = {
 
     /** Maximum number of retries when fetching fails */
     retries?: number;
+
+    ids?: string[];
 }
 
 export type StylesCommandOptions = {
@@ -65,6 +67,8 @@ export type StylesCommandOptions = {
 
     /** Outputter module name or path */
     outputters?: StyleOutputter[];
+
+    ids?: string[];
 }
 
 export type FigmaExportRC = {

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -17,7 +17,7 @@ export interface ComponentNode extends Figma.Component {
     svg: string;
 }
 
-export interface PageNode extends Figma.Canvas {
+export interface PageNode extends Figma.Global {
     components: ComponentNode[];
 }
 


### PR DESCRIPTION
This pull request aims to add support for exporting node subtrees by their node ID-s. This can be particularly useful in cases where the entire Figma file does not fit in the REST API limits due to either the response taking too long to generate or is too large. In such cases the developer can split the work by fetching certain sections individually or only pick sub-trees that are of interest to them.

The way it works for both styles and components is similar:
* Initial `client.file` request only uses `depth: 1`. This is used to verify that the document with specified version exists and then is used to gather the names and node id-s for pages. Using low depth here guarantees that the exporter will not choke on large files.
* Depending on use of `onlyFromPages`, some pages may be filtered out by name, then get translated to node id-s.
  * `ids` completely ignores this by supplying its own node id-s.
* Resulting node id-s are fetched using `client.fileNodes` request.
* File nodes gathered from response are converted to the internal `PageNode`/`StyleNode` format and processed as before.

There are also certain other improvements:
* Component information is not gathered for styles. This fixes #147 with resolution that presence of any component is not necessary to fetch styles for that page/node.
* Perform subsequent requests using the same version as the main document. Currently it is theoretically possible that the document version can change mid-exporting, which can be a source of strange errors (nodes get changed or deleted). Subsequent requests will use the version string specified in the response of the main `client.file`.

---

It is still pretty much work in progress (no tests, docs), but I feel it is ready enough that it should be able to produce usable output. I will try testing this on real world documents during the following week.

Currently the only performance issue I can imagine has to do with fetching the first round of nodes via `client.fileNodes`. All of the trees for "root nodes" are fetched in single request which may be subject to similar issues where when combined they are too large, but individually may be fetchable. Solution would be fetching each of these subtrees individually.

There are some concerns of breaking the API by changing the signatures of functions and types. Any feedback in that regard is more than welcome.

I do not mind if this gets closed in favor of a different approach or if you wish to pick up the work from here.