### PR TITLE
`onlyFromPages` can be used when exporting styles

### DIFF
--- a/.figmaexportrc.example.local.ts
+++ b/.figmaexportrc.example.local.ts
@@ -39,7 +39,7 @@ const styleOptions: StylesCommandOptions = {
 
 const componentOptions: ComponentsCommandOptions = {
     fileId: 'fzYhvQpqwhZDUImRz431Qo',
-    onlyFromPages: ['icons', 'unit-test', 'octicons-by-github'],
+    onlyFromPages: ['icons', 'unit-test', 'icons/octicons-by-github'],
     // concurrency: 30,
     transformers: [
         transformSvgWithSvgo({

--- a/.mocharc.integration.json
+++ b/.mocharc.integration.json
@@ -1,0 +1,6 @@
+{
+    "extension": ["js", "ts"],
+    "spec": "packages/**/integration.test.ts",
+    "require": "ts-node/register",
+    "file": ["test--registers.integration.ts"]
+}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -2,5 +2,6 @@
     "extension": ["js", "ts"],
     "spec": "packages/**/*.test.ts",
     "require": "ts-node/register",
-    "file": ["test--registers.ts", "test--packages.ts"]
-  }
+    "file": ["test--registers.ts", "test--packages.ts"],
+    "ignore": ["**/integration.test.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "tsc --build packages/**/tsconfig.json",
     "lint": "yarn build && eslint . --ignore-pattern=node_modules --ignore-pattern=output --ignore-pattern=dist --ext .js,.jsx,.ts",
     "test": "yarn build && TS_NODE_PROJECT='./tsconfig.mocha.json' mocha",
+    "test:integration": "yarn build && TS_NODE_PROJECT='./tsconfig.mocha.json' mocha --config .mocharc.integration.json",
     "test:watch": "yarn test --watch --reporter=dot",
     "coverage": "nyc yarn test --reporter=dot",
     "coverage:watch": "npx nodemon -e js,mjs,ts --exec yarn coverage",

--- a/packages/core/src/integration.test.ts
+++ b/packages/core/src/integration.test.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import { components as exportComponents } from './lib/export-components';
+import { styles as exportStyles } from './lib/export-styles';
+
+describe('@figma-export/core', () => {
+    it('Export components', async () => {
+        const pageNodes = await exportComponents({
+            fileId: 'fzYhvQpqwhZDUImRz431Qo',
+            token: process.env.FIGMA_TOKEN ?? '',
+            onlyFromPages: ['unit-test'],
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            log: () => {},
+        });
+
+        // console.info(pageNodes);
+
+        expect(pageNodes.length).to.eq(1);
+        expect(pageNodes[0].components.length).to.eq(4);
+        expect(pageNodes[0].components.map((c) => c.name)).to.eql([
+            'figma default logo',
+            'figma/logo',
+            'figma/logo/main',
+            'figma/logo/main (bright)',
+        ]);
+    }).timeout(60 * 1000);
+
+    it('Export styles', async () => {
+        const styles = await exportStyles({
+            fileId: 'fzYhvQpqwhZDUImRz431Qo',
+            token: process.env.FIGMA_TOKEN ?? '',
+            onlyFromPages: ['unit-test'],
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            log: () => { },
+        });
+
+        // console.info(styles);
+
+        expect(styles.length).to.eq(1);
+        expect(styles[0].name).to.eq('purple/with/special#characters');
+    }).timeout(60 * 1000);
+});

--- a/packages/core/src/lib/_config.test.ts
+++ b/packages/core/src/lib/_config.test.ts
@@ -147,8 +147,10 @@ export const createDocument = (props: any): Figma.Document => ({
 
 export const createPage = (children: any): Figma.Document => ({
     ...({} as Figma.Document),
+    type: 'DOCUMENT',
     children: [{
         ...({} as Figma.Canvas),
+        type: 'CANVAS',
         id: '10:8',
         name: 'fakePage',
         children,

--- a/packages/core/src/lib/export-components.test.ts
+++ b/packages/core/src/lib/export-components.test.ts
@@ -88,7 +88,53 @@ describe('export-component', () => {
             ids: ['10:8', '8:1', '9:1'],
             svg_include_id: true,
         });
-        expect(clientFile).to.have.been.calledOnceWithExactly('fileABCD', { version: 'versionABCD' });
+
+        expect(clientFile).to.have.been.calledOnce;
+        expect(clientFile.firstCall).to.have.been.calledWith('fileABCD', {
+            version: 'versionABCD', depth: undefined, ids: undefined,
+        });
+
+        expect(logger).to.have.been.callCount(6);
+        expect(logger.getCall(0)).to.have.been.calledWith('fetching document');
+        expect(logger.getCall(1)).to.have.been.calledWith('preparing components');
+        expect(logger.getCall(2)).to.have.been.calledWith('fetching components 1/3');
+        expect(logger.getCall(3)).to.have.been.calledWith('fetching components 2/3');
+        expect(logger.getCall(4)).to.have.been.calledWith('fetching components 3/3');
+        expect(logger.getCall(5)).to.have.been.calledWith('exported components from fileABCD');
+
+        expect(transformer).to.have.been.calledThrice;
+        expect(transformer.firstCall).to.have.been.calledWith(figmaDocument.svg.content);
+        expect(transformer.secondCall).to.have.been.calledWith(figmaDocument.svg.content);
+        expect(transformer.thirdCall).to.have.been.calledWith(figmaDocument.svg.content);
+
+        expect(outputter).to.have.been.calledOnceWithExactly(pagesWithSvg);
+    });
+
+    it('should filter by selected page names when setting onlyFromPages', async () => {
+        const pagesWithSvg = await exportComponents({
+            fileId: 'fileABCD',
+            version: 'versionABCD',
+            token: 'token1234',
+            log: logger,
+            outputters: [outputter],
+            transformers: [transformer],
+            onlyFromPages: ['page2'],
+        });
+
+        nockScope.done();
+
+        expect(FigmaExport.getClient).to.have.been.calledOnceWithExactly('token1234');
+        expect(clientFileImages).to.have.been.calledOnceWith('fileABCD', {
+            format: 'svg',
+            ids: ['10:8', '8:1', '9:1'],
+            svg_include_id: true,
+        });
+
+        expect(clientFile).to.have.been.calledTwice;
+        expect(clientFile.firstCall).to.have.been.calledWith('fileABCD', { version: 'versionABCD', depth: 1, ids: undefined });
+        expect(clientFile.secondCall).to.have.been.calledWith('fileABCD', {
+            version: 'versionABCD', depth: undefined, ids: ['10:7'],
+        });
 
         expect(logger).to.have.been.callCount(6);
         expect(logger.getCall(0)).to.have.been.calledWith('fetching document');
@@ -147,7 +193,12 @@ describe('export-component', () => {
             ids: ['10:8'],
             svg_include_id: true,
         });
-        expect(clientFile).to.have.been.calledOnceWithExactly('fileABCD', { version: 'versionABCD' });
+
+        expect(clientFile).to.have.been.calledOnce;
+        expect(clientFile.firstCall).to.have.been.calledWith(
+            'fileABCD',
+            { version: 'versionABCD', depth: undefined, ids: undefined },
+        );
 
         expect(logger).to.have.been.callCount(4);
         expect(logger.getCall(0)).to.have.been.calledWith('fetching document');

--- a/packages/core/src/lib/export-components.test.ts
+++ b/packages/core/src/lib/export-components.test.ts
@@ -87,6 +87,7 @@ describe('export-component', () => {
             format: 'svg',
             ids: ['10:8', '8:1', '9:1'],
             svg_include_id: true,
+            version: 'versionABCD',
         });
 
         expect(clientFile).to.have.been.calledOnce;
@@ -128,6 +129,7 @@ describe('export-component', () => {
             format: 'svg',
             ids: ['10:8', '8:1', '9:1'],
             svg_include_id: true,
+            version: 'versionABCD',
         });
 
         expect(clientFile).to.have.been.calledTwice;
@@ -192,6 +194,7 @@ describe('export-component', () => {
             format: 'svg',
             ids: ['10:8'],
             svg_include_id: true,
+            version: 'versionABCD',
         });
 
         expect(clientFile).to.have.been.calledOnce;

--- a/packages/core/src/lib/export-components.ts
+++ b/packages/core/src/lib/export-components.ts
@@ -1,6 +1,6 @@
 import * as FigmaExport from '@figma-export/types';
 
-import { getClient, getPages, enrichPagesWithSvg } from './figma';
+import { getClient, getPagesWithComponents, enrichPagesWithSvg } from './figma';
 
 export const components: FigmaExport.ComponentsCommand = async ({
     token,
@@ -28,7 +28,7 @@ export const components: FigmaExport.ComponentsCommand = async ({
         throw new Error('\'document\' is missing.');
     }
 
-    const pages = getPages((document), { only: onlyFromPages, filter: filterComponent });
+    const pages = getPagesWithComponents(document, { only: onlyFromPages, filter: filterComponent });
 
     log('preparing components');
     const pagesWithSvg = await enrichPagesWithSvg(client, fileId, pages, {

--- a/packages/core/src/lib/export-components.ts
+++ b/packages/core/src/lib/export-components.ts
@@ -37,7 +37,7 @@ export const components: FigmaExport.ComponentsCommand = async ({
     const pages = getPagesWithComponents(figmaDocument, { filterComponent });
 
     log('preparing components');
-    const pagesWithSvg = await enrichPagesWithSvg(client, fileId, pages, {
+    const pagesWithSvg = await enrichPagesWithSvg(client, fileId, pages, version, {
         transformers,
         concurrency,
         retries,

--- a/packages/core/src/lib/export-components.ts
+++ b/packages/core/src/lib/export-components.ts
@@ -1,6 +1,11 @@
 import * as FigmaExport from '@figma-export/types';
 
-import { getClient, getPagesWithComponents, enrichPagesWithSvg } from './figma';
+import {
+    getClient,
+    enrichPagesWithSvg,
+    getDocument,
+    getPagesWithComponents,
+} from './figma';
 
 export const components: FigmaExport.ComponentsCommand = async ({
     token,
@@ -20,15 +25,16 @@ export const components: FigmaExport.ComponentsCommand = async ({
     const client = getClient(token);
 
     log('fetching document');
-    const { data: { document = null } = {} } = await client.file(fileId, { version }).catch((error: Error) => {
-        throw new Error(`while fetching file "${fileId}${version ? `?version=${version}` : ''}": ${error.message}`);
-    });
+    const figmaDocument = await getDocument(
+        client,
+        {
+            fileId,
+            version,
+            onlyFromPages,
+        },
+    );
 
-    if (!document) {
-        throw new Error('\'document\' is missing.');
-    }
-
-    const pages = getPagesWithComponents(document, { only: onlyFromPages, filter: filterComponent });
+    const pages = getPagesWithComponents(figmaDocument, { filterComponent });
 
     log('preparing components');
     const pagesWithSvg = await enrichPagesWithSvg(client, fileId, pages, {

--- a/packages/core/src/lib/export-styles.test.ts
+++ b/packages/core/src/lib/export-styles.test.ts
@@ -47,7 +47,7 @@ describe('export-styles', () => {
         sinon.restore();
     });
 
-    it('should use outputter to export styles', async () => {
+    it('should use outputter to export styles without defining the "onlyFromPages" option', async () => {
         const pagesWithSvg = await exportStyles({
             fileId: 'fileABCD',
             version: 'versionABCD',
@@ -58,8 +58,8 @@ describe('export-styles', () => {
 
         expect(FigmaExport.getClient).to.have.been.calledOnceWithExactly('token1234');
         expect(clientFileNodes).to.have.been.calledOnceWith('fileABCD', { ids: fileNodeIds, version: 'versionABCD' });
-        expect(clientFile.firstCall).to.have.been.calledWith('fileABCD', { version: 'versionABCD', depth: 1 });
-        expect(clientFile.secondCall).to.have.been.calledWith('fileABCD', { version: 'versionABCD', ids: undefined });
+        expect(clientFile).to.have.been.calledOnce;
+        expect(clientFile.firstCall).to.have.been.calledWith('fileABCD', { version: 'versionABCD', depth: undefined, ids: undefined });
 
         expect(logger).to.have.been.callCount(4);
         expect(logger.getCall(0)).to.have.been.calledWith('fetching document');
@@ -74,7 +74,7 @@ describe('export-styles', () => {
         const pagesWithSvg = await exportStyles({
             fileId: 'fileABCD',
             version: 'versionABCD',
-            onlyFromPages: ['octicons-by-github'],
+            onlyFromPages: ['icons/octicons-by-github'],
             token: 'token1234',
             log: logger,
             outputters: [outputter],
@@ -82,8 +82,9 @@ describe('export-styles', () => {
 
         expect(FigmaExport.getClient).to.have.been.calledOnceWithExactly('token1234');
         expect(clientFileNodes).to.have.been.calledOnceWith('fileABCD', { ids: fileNodeIds, version: 'versionABCD' });
-        expect(clientFile.firstCall).to.have.been.calledWith('fileABCD', { version: 'versionABCD', depth: 1 });
-        expect(clientFile.secondCall).to.have.been.calledWith('fileABCD', { version: 'versionABCD', ids: ['254:0'] });
+        expect(clientFile).to.have.been.calledTwice;
+        expect(clientFile.firstCall).to.have.been.calledWith('fileABCD', { version: 'versionABCD', depth: 1, ids: undefined });
+        expect(clientFile.secondCall).to.have.been.calledWith('fileABCD', { version: 'versionABCD', depth: undefined, ids: ['254:0'] });
 
         expect(logger).to.have.been.callCount(4);
         expect(logger.getCall(0)).to.have.been.calledWith('fetching document');
@@ -118,8 +119,7 @@ describe('export-styles', () => {
     });
 
     it('should throw an error when fetching styles fails', async () => {
-        clientFile.onFirstCall().returns(Promise.resolve({ data: { document: file.document } }));
-        clientFile.onSecondCall().returns(Promise.reject(new Error('some error')));
+        clientFile.onFirstCall().returns(Promise.reject(new Error('some error')));
 
         await expect(exportStyles({
             fileId: 'fileABCD',
@@ -133,7 +133,7 @@ describe('export-styles', () => {
         await expect(exportStyles({
             fileId: 'fileABCD',
             token: 'token1234',
-        })).to.be.rejectedWith(Error, '\'document\' is missing.');
+        })).to.be.rejectedWith(Error, '\'styles\' are missing.');
     });
 
     it('should throw an error if styles property is missing when fetching file', async () => {

--- a/packages/core/src/lib/export-styles.ts
+++ b/packages/core/src/lib/export-styles.ts
@@ -1,6 +1,6 @@
 import * as FigmaExport from '@figma-export/types';
 
-import { getClient, getPages } from './figma';
+import { getPages, getClient } from './figma';
 import { fetchStyles, parseStyles } from './figmaStyles';
 
 export const styles: FigmaExport.StylesCommand = async ({
@@ -25,7 +25,7 @@ export const styles: FigmaExport.StylesCommand = async ({
         throw new Error('\'document\' is missing.');
     }
 
-    const ids = getPages((document), { only: onlyFromPages })
+    const ids = getPages(document, onlyFromPages)
         .map((page) => page.id);
 
     log('fetching styles');

--- a/packages/core/src/lib/figma.test.ts
+++ b/packages/core/src/lib/figma.test.ts
@@ -38,42 +38,42 @@ describe('figma.', () => {
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1, figmaDocument.page2] });
 
         it('should get all pages by default', () => {
-            expect(figma.getPages(document))
+            expect(figma.getPagesWithComponents(document))
                 .to.contain.an.item.with.property('name', 'page1')
                 .to.contain.an.item.with.property('name', 'page2');
         });
 
         it('should get all pages if "empty" list is provided', () => {
-            expect(figma.getPages(document, { only: [''] }))
+            expect(figma.getPagesWithComponents(document, { only: [''] }))
                 .to.contain.an.item.with.property('name', 'page1')
                 .to.contain.an.item.with.property('name', 'page2');
 
-            expect(figma.getPages(document, { only: [] }))
+            expect(figma.getPagesWithComponents(document, { only: [] }))
                 .to.contain.an.item.with.property('name', 'page1')
                 .to.contain.an.item.with.property('name', 'page2');
 
-            expect(figma.getPages(document, { only: '' }))
+            expect(figma.getPagesWithComponents(document, { only: '' }))
                 .to.contain.an.item.with.property('name', 'page1')
                 .to.contain.an.item.with.property('name', 'page2');
         });
 
         it('should get all requested pages', () => {
-            expect(figma.getPages(document, { only: 'page2' }))
+            expect(figma.getPagesWithComponents(document, { only: 'page2' }))
                 .to.not.contain.an.item.with.property('name', 'page1')
                 .to.contain.an.item.with.property('name', 'page2');
 
-            expect(figma.getPages(document, { only: ['page1', 'page2'] }))
+            expect(figma.getPagesWithComponents(document, { only: ['page1', 'page2'] }))
                 .to.contain.an.item.with.property('name', 'page1')
                 .to.contain.an.item.with.property('name', 'page2');
         });
 
         it('should get zero results if a non existing page is provided', () => {
-            expect(figma.getPages(document, { only: 'page20' }))
+            expect(figma.getPagesWithComponents(document, { only: 'page20' }))
                 .to.be.an('array').that.is.empty;
         });
 
         it('should excludes pages without components', () => {
-            const pages = figma.getPages(
+            const pages = figma.getPagesWithComponents(
                 figmaDocument.createDocument({
                     children: [
                         figmaDocument.page1,
@@ -92,7 +92,7 @@ describe('figma.', () => {
     describe('getIdsFromPages', () => {
         it('should get component ids from specified pages', () => {
             const document = figmaDocument.createDocument({ children: [figmaDocument.page1, figmaDocument.page2] });
-            const pages = figma.getPages(document, {
+            const pages = figma.getPagesWithComponents(document, {
                 only: 'page2',
             });
 

--- a/packages/core/src/lib/figma.test.ts
+++ b/packages/core/src/lib/figma.test.ts
@@ -126,6 +126,7 @@ describe('figma.', () => {
                 ids: ['A1', 'B2'],
                 format: 'svg',
                 svg_include_id: true,
+                version: undefined,
             });
 
             expect(fileImages).to.deep.equal({
@@ -165,6 +166,7 @@ describe('figma.', () => {
                 ids: ['A1', 'B1'],
                 format: 'svg',
                 svg_include_id: true,
+                version: undefined,
             });
 
             expect(fileSvgs).to.deep.equal({

--- a/packages/core/src/lib/figma.test.ts
+++ b/packages/core/src/lib/figma.test.ts
@@ -18,6 +18,17 @@ describe('figma.', () => {
         sinon.restore();
     });
 
+    describe('', () => {
+        it('should throw an error if styles are not present', async () => {
+            const client = {
+                ...({} as Figma.ClientInterface),
+                file: sinon.stub().resolves({ data: {} }),
+            };
+
+            await expect(figma.getStyles(client, { fileId: 'ABC123' })).to.be.rejectedWith(Error, '\'styles\' are missing.');
+        });
+    });
+
     describe('getComponents', () => {
         it('should get zero results if no children are provided', () => {
             expect(figma.getComponents()).to.eql([]);
@@ -34,7 +45,7 @@ describe('figma.', () => {
         });
     });
 
-    describe('getPages', () => {
+    describe('getPagesWithComponents', () => {
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1, figmaDocument.page2] });
 
         it('should get all pages by default', () => {
@@ -43,33 +54,16 @@ describe('figma.', () => {
                 .to.contain.an.item.with.property('name', 'page2');
         });
 
-        it('should get all pages if "empty" list is provided', () => {
-            expect(figma.getPagesWithComponents(document, { only: [''] }))
-                .to.contain.an.item.with.property('name', 'page1')
-                .to.contain.an.item.with.property('name', 'page2');
-
-            expect(figma.getPagesWithComponents(document, { only: [] }))
-                .to.contain.an.item.with.property('name', 'page1')
-                .to.contain.an.item.with.property('name', 'page2');
-
-            expect(figma.getPagesWithComponents(document, { only: '' }))
+        it('should get all the pages from the document', () => {
+            expect(figma.getPagesWithComponents(document))
                 .to.contain.an.item.with.property('name', 'page1')
                 .to.contain.an.item.with.property('name', 'page2');
         });
 
-        it('should get all requested pages', () => {
-            expect(figma.getPagesWithComponents(document, { only: 'page2' }))
+        it('should be able to filter components', () => {
+            expect(figma.getPagesWithComponents(document, { filterComponent: (component) => ['9:1'].includes(component.id) }))
                 .to.not.contain.an.item.with.property('name', 'page1')
                 .to.contain.an.item.with.property('name', 'page2');
-
-            expect(figma.getPagesWithComponents(document, { only: ['page1', 'page2'] }))
-                .to.contain.an.item.with.property('name', 'page1')
-                .to.contain.an.item.with.property('name', 'page2');
-        });
-
-        it('should get zero results if a non existing page is provided', () => {
-            expect(figma.getPagesWithComponents(document, { only: 'page20' }))
-                .to.be.an('array').that.is.empty;
         });
 
         it('should excludes pages without components', () => {
@@ -92,11 +86,9 @@ describe('figma.', () => {
     describe('getIdsFromPages', () => {
         it('should get component ids from specified pages', () => {
             const document = figmaDocument.createDocument({ children: [figmaDocument.page1, figmaDocument.page2] });
-            const pages = figma.getPagesWithComponents(document, {
-                only: 'page2',
-            });
+            const pages = figma.getPagesWithComponents(document);
 
-            expect(figma.getIdsFromPages(pages)).to.eql(['9:1']);
+            expect(figma.getIdsFromPages(pages)).to.eql(['10:8', '8:1', '9:1']);
         });
     });
 

--- a/packages/core/src/lib/figma.ts
+++ b/packages/core/src/lib/figma.ts
@@ -134,11 +134,12 @@ export const getComponents = (
     return components;
 };
 
-export const getDocument = async (
+// eslint-disable-next-line no-underscore-dangle
+const __getDocumentAndStyles = async (
     client: Figma.ClientInterface,
     options: PickOption<FigmaExport.ComponentsCommand, 'fileId' | 'version' | 'onlyFromPages'>,
-): Promise<Figma.Document> => {
-    const { document } = await getFile(
+): ReturnType<typeof getFile> => {
+    return getFile(
         client,
         options,
         {
@@ -148,8 +149,15 @@ export const getDocument = async (
                 : undefined,
         },
     );
+};
 
-    if (!document) {
+export const getDocument = async (
+    client: Figma.ClientInterface,
+    options: PickOption<FigmaExport.ComponentsCommand, 'fileId' | 'version' | 'onlyFromPages'>,
+): Promise<Figma.Document> => {
+    const { document } = await __getDocumentAndStyles(client, options);
+
+    if (document == null) {
         throw new Error('\'document\' is missing.');
     }
 
@@ -162,18 +170,9 @@ export const getStyles = async (
 ): Promise<{
     readonly [key: string]: Figma.Style
 }> => {
-    const { styles } = await getFile(
-        client,
-        options,
-        {
-            // when `onlyFromPages` is set, we avoid traversing all the document tree, but instead we get only requested ids.
-            ids: sanitizeOnlyFromPages(options.onlyFromPages).length > 0
-                ? await getAllPageIds(client, options)
-                : undefined,
-        },
-    );
+    const { styles } = await __getDocumentAndStyles(client, options);
 
-    if (!styles) {
+    if (styles == null) {
         throw new Error('\'styles\' are missing.');
     }
 

--- a/packages/core/src/lib/figmaStyles/effectStyle.ts
+++ b/packages/core/src/lib/figmaStyles/effectStyle.ts
@@ -1,7 +1,7 @@
 import * as Figma from 'figma-js';
 import * as FigmaExport from '@figma-export/types';
 
-import { notEmpty } from '../utils';
+import { notNullish } from '../utils';
 import { extractColor } from './paintStyle';
 
 const createEffectStyle = (effect: Figma.Effect): FigmaExport.EffectStyle | undefined => {
@@ -51,7 +51,7 @@ const parse = (node: FigmaExport.StyleNode): FigmaExport.StyleTypeEffect | undef
             effects: Array.from(node.effects)
                 .reverse()
                 .map(createEffectStyle)
-                .filter(notEmpty),
+                .filter(notNullish),
         };
     }
 

--- a/packages/core/src/lib/figmaStyles/index.ts
+++ b/packages/core/src/lib/figmaStyles/index.ts
@@ -1,7 +1,7 @@
 import * as Figma from 'figma-js';
 import * as FigmaExport from '@figma-export/types';
 
-import { notEmpty } from '../utils';
+import { notNullish } from '../utils';
 
 import { parse as parsePaintStyle } from './paintStyle';
 import { parse as parseEffectStyle } from './effectStyle';
@@ -11,18 +11,16 @@ import { parse as parseTextStyle } from './textStyle';
 const fetchStyles = async (
     client: Figma.ClientInterface,
     fileId: string,
+    styles: { readonly [key: string]: Figma.Style },
     version?: string,
-    ids?: string[],
 ): Promise<FigmaExport.StyleNode[]> => {
-    const { data: { styles = null } = {} } = await client.file(fileId, { version, ids }).catch((error: Error) => {
-        throw new Error(`while fetching file "${fileId}${version ? `?version=${version}` : ''}": ${error.message}`);
-    });
+    const styleIds = Object.keys(styles);
 
-    if (!styles) {
-        throw new Error('\'styles\' are missing.');
+    if (styleIds.length === 0) {
+        throw new Error('No styles found');
     }
 
-    const { data: { nodes } } = await client.fileNodes(fileId, { ids: Object.keys(styles), version }).catch((error: Error) => {
+    const { data: { nodes } } = await client.fileNodes(fileId, { ids: styleIds, version }).catch((error: Error) => {
         throw new Error(`while fetching fileNodes: ${error.message}`);
     });
 
@@ -53,7 +51,7 @@ const parseStyles = (styleNodes: FigmaExport.StyleNode[]): FigmaExport.Style[] =
             originalNode: node,
             ...parsedStyles,
         };
-    }).filter(notEmpty);
+    }).filter(notNullish);
 };
 
 export {

--- a/packages/core/src/lib/figmaStyles/paintStyle.ts
+++ b/packages/core/src/lib/figmaStyles/paintStyle.ts
@@ -1,7 +1,7 @@
 import * as Figma from 'figma-js';
 import * as FigmaExport from '@figma-export/types';
 
-import { notEmpty } from '../utils';
+import { notNullish } from '../utils';
 
 const extractColor = ({ color, opacity = 1 }: FigmaExport.ExtractableColor): (FigmaExport.Color | undefined) => {
     if (!color) {
@@ -106,7 +106,7 @@ const parse = (node: FigmaExport.StyleNode): FigmaExport.StyleTypeFill | undefin
             fills: Array.from(node.fills)
                 .reverse()
                 .map(createFillStyles)
-                .filter(notEmpty),
+                .filter(notNullish),
         };
     }
 

--- a/packages/core/src/lib/utils.test.ts
+++ b/packages/core/src/lib/utils.test.ts
@@ -6,6 +6,8 @@ import * as utils from './utils';
 describe('utils.', () => {
     describe('toArray', () => {
         it('should convert the element into an array if the element is not an array. If is already an array, just returns it', () => {
+            expect(utils.toArray(undefined)).to.eql([undefined]);
+            expect(utils.toArray(null)).to.eql([null]);
             expect(utils.toArray('')).to.eql(['']);
             expect(utils.toArray('this is a string')).to.eql(['this is a string']);
             expect(utils.toArray(2)).to.eql([2]);
@@ -72,6 +74,40 @@ describe('utils.', () => {
             expect(
                 utils.chunk([10, 20, 30], 1),
             ).to.deep.equal([[10], [20], [30]]);
+        });
+    });
+
+    describe('notNullish', () => {
+        it('should return `false` when provided value is nullish', () => {
+            expect(utils.notNullish(null)).to.been.false;
+            expect(utils.notNullish(undefined)).to.been.false;
+            expect(utils.notNullish('John')).to.been.true;
+            expect(utils.notNullish(23)).to.been.true;
+
+            expect(
+                [23, null, null, 'John', undefined].filter(utils.notNullish),
+            ).to.deep.equal([23, 'John']);
+        });
+    });
+
+    describe('notEmptyString', () => {
+        it('should return `false` when provided value is an empty string', () => {
+            expect(utils.notEmptyString('')).to.been.false;
+            expect(utils.notEmptyString('           ')).to.been.false;
+            expect(utils.notEmptyString('John')).to.been.true;
+
+            expect(
+                ['', 'John', '       '].filter(utils.notEmptyString),
+            ).to.deep.equal(['John']);
+        });
+    });
+
+    describe('sanitizeOnlyFromPages', () => {
+        it('should return a not nullish and not empty string array', () => {
+            expect(utils.sanitizeOnlyFromPages(undefined)).to.deep.equal([]);
+            expect(utils.sanitizeOnlyFromPages([''])).to.deep.equal([]);
+            expect(utils.sanitizeOnlyFromPages(['John'])).to.deep.equal(['John']);
+            expect(utils.sanitizeOnlyFromPages(['John', 'Doe'])).to.deep.equal(['John', 'Doe']);
         });
     });
 });

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import * as FigmaExport from '@figma-export/types';
 
 export const toArray = <T>(any: T | T[]): T[] => (Array.isArray(any) ? any : [any]);
 
@@ -50,6 +51,34 @@ export const fetchAsSvgXml = (url: string): Promise<string> => {
     });
 };
 
-export const notEmpty = <TValue>(value: TValue | null | undefined): value is TValue => {
+/**
+ * Check whether the provided value is `undefined` or `null`. It this case it will return `false`.
+ *
+ * Useful when you need to exclude nullish values from a list.
+ * @example [23, null, null, 'John', undefined].filter(notNullish) //= [23, 'John']
+ */
+export const notNullish = <T>(value: T | null | undefined): value is T => {
     return value !== null && value !== undefined;
 };
+
+/**
+ * Check whether the given string is not empty.
+ *
+ * Useful when you need to exclude empty strings from a list.
+ * @example ['', 'John'].filter(notEmptyString) //= ['John']
+ */
+export function notEmptyString(value: string): boolean {
+    return value.trim() !== '';
+}
+
+export type PickOption<T extends FigmaExport.ComponentsCommand | FigmaExport.StylesCommand, K extends keyof Parameters<T>[0]> =
+    Pick<Parameters<T>[0], K>
+
+/**
+ * Sanitize `onlyFromPages` option by converting to a not nullish and not empty string array.
+ */
+export function sanitizeOnlyFromPages(
+    onlyFromPages: PickOption<FigmaExport.ComponentsCommand | FigmaExport.StylesCommand, 'onlyFromPages'>['onlyFromPages'],
+) {
+    return (onlyFromPages ?? []).filter((v) => notNullish(v) && notEmptyString(v));
+}

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export const toArray = <T>(any: T): T[] => (Array.isArray(any) ? any : [any]);
+export const toArray = <T>(any: T | T[]): T[] => (Array.isArray(any) ? any : [any]);
 
 export const emptySvg = '<svg></svg>';
 

--- a/packages/output-components-as-es6/src/index.test.ts
+++ b/packages/output-components-as-es6/src/index.test.ts
@@ -162,7 +162,7 @@ describe('outputter as es6', () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
         const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
-        const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages, {
+        const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages, undefined, {
             transformers: [async () => undefined],
         });
 

--- a/packages/output-components-as-es6/src/index.test.ts
+++ b/packages/output-components-as-es6/src/index.test.ts
@@ -70,7 +70,7 @@ describe('outputter as es6', () => {
     it('should export all components into an es6 file', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();
@@ -91,7 +91,7 @@ describe('outputter as es6', () => {
     it('should use "variablePrefix" and "variableSuffix" options to prepend or append a text to the variable name', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();
@@ -113,7 +113,7 @@ describe('outputter as es6', () => {
     it('should export all components into an es6 file using base64 encoding if set', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();
@@ -134,7 +134,7 @@ describe('outputter as es6', () => {
     it('should export all components into an es6 file using dataUrl if set', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();
@@ -161,7 +161,7 @@ describe('outputter as es6', () => {
     it('should not break when transformers return "undefined"', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages, {
             transformers: [async () => undefined],
         });
@@ -190,7 +190,7 @@ describe('outputter as es6', () => {
         sinon.stub(fs, 'writeFileSync');
 
         const document = figmaDocument.createDocument({ children: [page] });
-        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
         const spyOutputter = sinon.spy(outputter);
 
         return spyOutputter({
@@ -212,7 +212,7 @@ describe('outputter as es6', () => {
         sinon.stub(fs, 'writeFileSync');
 
         const document = figmaDocument.createDocument({ children: [page] });
-        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
         const spyOutputter = sinon.spy(outputter);
 
         return spyOutputter({
@@ -228,7 +228,7 @@ describe('outputter as es6', () => {
     it('should create folders and subfolders when pageName contains slashes', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1WithSlashes] });
-        const pages: FigmaExport.PageNode[] = figma.getPages(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();

--- a/packages/output-components-as-stdout/src/index.test.ts
+++ b/packages/output-components-as-stdout/src/index.test.ts
@@ -10,7 +10,7 @@ import outputter = require('./index');
 describe('outputter as stdout', () => {
     it('should output pages in console as json', async () => {
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages = figma.getPages(document);
+        const pages = figma.getPagesWithComponents(document);
         await outputter()(pages);
         expect(console.log).to.have.been.calledOnce;
         expect(console.log).to.have.been.calledWith(`${JSON.stringify(pages)}`);

--- a/packages/output-components-as-svg/src/index.test.ts
+++ b/packages/output-components-as-svg/src/index.test.ts
@@ -19,7 +19,7 @@ describe('outputter as svg', () => {
     it('should export all components into svg files', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages = figma.getPages(document);
+        const pages = figma.getPagesWithComponents(document);
 
         await outputter({
             output: 'output',
@@ -33,7 +33,7 @@ describe('outputter as svg', () => {
     it('should create folder if component names contain slashes', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const fakePages = figmaDocument.createPage([figmaDocument.componentWithSlashedName]);
-        const pages = figma.getPages(fakePages);
+        const pages = figma.getPagesWithComponents(fakePages);
 
         await outputter({
             output: 'output',
@@ -45,7 +45,7 @@ describe('outputter as svg', () => {
 
     describe('options', () => {
         const fakePages = figmaDocument.createPage([figmaDocument.componentWithSlashedName]);
-        const pages = figma.getPages(fakePages);
+        const pages = figma.getPagesWithComponents(fakePages);
 
         it('should be able to customize "basename"', async () => {
             const writeFileSync = sinon.stub(fs, 'writeFileSync');

--- a/packages/output-components-as-svgr/src/index.test.ts
+++ b/packages/output-components-as-svgr/src/index.test.ts
@@ -56,7 +56,7 @@ describe('outputter as svgr', () => {
 
     it('should export all components into jsx files plus one index.js for each folder', async () => {
         const fakePage = figmaDocument.createPage([figmaDocument.component1, figmaDocument.component2]);
-        const pages = figma.getPages(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage);
 
         await outputter({
             output: 'output',
@@ -73,7 +73,7 @@ describe('outputter as svgr', () => {
 
     it('should export all components into tsx files plus one index.ts for each folder', async () => {
         const fakePage = figmaDocument.createPage([figmaDocument.component1, figmaDocument.component2]);
-        const pages = figma.getPages(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage);
 
         await outputter({
             output: 'output',
@@ -91,7 +91,7 @@ describe('outputter as svgr', () => {
 
     it('should create a custom export for every component using the template passed', async () => {
         const fakePage = figmaDocument.createPage([figmaDocument.component2]);
-        const pages = figma.getPages(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage);
 
         await outputter({
             output: 'output',
@@ -108,7 +108,7 @@ describe('outputter as svgr', () => {
 
     it('should create folder if component names contain slashes', async () => {
         const fakePage = figmaDocument.createPage([figmaDocument.componentWithSlashedName]);
-        const pages = figma.getPages(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage);
 
         await outputter({
             output: 'output',
@@ -121,7 +121,7 @@ describe('outputter as svgr', () => {
 
     describe('options', () => {
         const fakePage = figmaDocument.createPage([figmaDocument.componentWithSlashedName]);
-        const pages = figma.getPages(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage);
 
         it('should be able to customize "dirname"', async () => {
             await outputter({

--- a/packages/output-components-as-svgstore/src/index.test.ts
+++ b/packages/output-components-as-svgstore/src/index.test.ts
@@ -23,7 +23,7 @@ describe('outputter as svgstore', () => {
     it('should create an svg with the page name as filename', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages = figma.getPages(document);
+        const pages = figma.getPagesWithComponents(document);
 
         await outputter({
             output: 'output',
@@ -45,7 +45,7 @@ describe('outputter as svgstore', () => {
     it('should create folders and subfolders when pageName contains slashes', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1WithSlashes] });
-        const pages = figma.getPages(document);
+        const pages = figma.getPagesWithComponents(document);
 
         await outputter({
             output: 'output',

--- a/packages/website/.figmaexportrc.js
+++ b/packages/website/.figmaexportrc.js
@@ -14,7 +14,7 @@ module.exports = {
 
         ['components', {
             fileId: 'fzYhvQpqwhZDUImRz431Qo',
-            onlyFromPages: ['octicons-by-github'],
+            onlyFromPages: ['icons/octicons-by-github'],
             outputters: [
                 require('../output-components-as-es6')({
                     output: './output/es6-dataurl-octicons',

--- a/packages/website/src/GitHubLink.jsx
+++ b/packages/website/src/GitHubLink.jsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-unresolved, import/extensions
-import { iconMarkGithub } from '../output/es6-dataurl-octicons/octicons-by-github';
+import { iconMarkGithub } from '../output/es6-dataurl-octicons/icons/octicons-by-github';
 
 const GitHubLink = () => (
     <div className="github-link">

--- a/packages/website/src/SvgOcticons.jsx
+++ b/packages/website/src/SvgOcticons.jsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-unresolved, import/extensions
-import * as Octicons from '../output/es6-dataurl-octicons/octicons-by-github';
+import * as Octicons from '../output/es6-dataurl-octicons/icons/octicons-by-github';
 
 // eslint-disable-next-line import/no-unresolved, import/extensions
 import { figmaArrow } from '../output/es6-dataurl/icons';

--- a/packages/website/src/output-components/ComponentsAsSvgr_default.jsx
+++ b/packages/website/src/output-components/ComponentsAsSvgr_default.jsx
@@ -4,7 +4,7 @@ import CodeBlock from '../components/CodeBlock';
 import * as FigmaIcons from '../../output/svgr/icons';
 
 // eslint-disable-next-line import/no-unresolved, import/extensions
-import { Squirrel } from '../../output/svgr-octicons/octicons-by-github';
+import { Squirrel } from '../../output/svgr-octicons/icons/octicons-by-github';
 
 const props = {
     title: (
@@ -16,7 +16,7 @@ const props = {
         <>
             You can easily import the generated <code>.jsx</code> files into your project and
             start using your Figma components as React components.<br />
-            <code>import {'{ Squirrel }'} from &apos;./output/octicons-by-github&apos;;</code>
+            <code>import {'{ Squirrel }'} from &apos;./output/icons/octicons-by-github&apos;;</code>
         </>
     ),
     code: `
@@ -24,7 +24,7 @@ const props = {
             commands: [
                 ['components', {
                     fileId: 'fzYhvQpqwhZDUImRz431Qo',
-                    onlyFromPages: ['octicons-by-github'],
+                    onlyFromPages: ['icons/octicons-by-github'],
                     outputters: [
                         // https://www.npmjs.com/package/@figma-export/output-components-as-svgr
                         require('@figma-export/output-components-as-svgr')({

--- a/test--packages.ts
+++ b/test--packages.ts
@@ -19,8 +19,9 @@ const getTestFiles = (dir: string, startDir: string = dir): string[] => {
 
         const isNodeModules = /node_modules/.test(dir);
         const isTestFile = /\.test\.[j|t]s$/.test(file);
+        const isIntegrationFile = /integration\.test\.[j|t]s$/.test(file);
 
-        if (!isNodeModules && isTestFile) {
+        if (!isNodeModules && isTestFile && !isIntegrationFile) {
             filelist.push(`${dir}${file}`);
         }
     });

--- a/test--registers.integration.ts
+++ b/test--registers.integration.ts
@@ -1,0 +1,26 @@
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+import sinon from 'sinon';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiThings from 'chai-things';
+import chaiAsPromises from 'chai-as-promised';
+
+chai.use(sinonChai);
+chai.use(chaiThings);
+chai.use(chaiAsPromises);
+
+let consoleSandbox: sinon.SinonSandbox;
+beforeEach(() => {
+    consoleSandbox = sinon.createSandbox();
+    // console.log = consoleSandbox.spy();
+    // console.error = consoleSandbox.spy();
+    // console.warn = consoleSandbox.spy();
+    // console.clear = consoleSandbox.spy();
+    // console.info = consoleSandbox.spy();
+});
+
+afterEach(() => {
+    consoleSandbox.restore();
+});


### PR DESCRIPTION
`onlyFromPages` can now be used when exporting styles. I also took the opportunity to remove a lot of code duplications.