### PR TITLE
Filter for string urls only

### DIFF
--- a/packages/core/src/lib/figma.ts
+++ b/packages/core/src/lib/figma.ts
@@ -235,7 +235,7 @@ export const fileSvgs = async (
     const images = await getImages(client, fileId, ids, version);
     const limit = pLimit(concurrency);
     let index = 0;
-    const svgPromises = Object.entries(images).map(async ([id, url]) => {
+    const svgPromises = Object.entries(images).filter(([,url]) => typeof url === "string").map(async ([id, url]) => {
         const svg = await limit(
             () => pRetry(() => fetchAsSvgXml(url), { retries }),
         );


### PR DESCRIPTION
I was facing this in all cases with our Figma files:

```
TypeError: Only absolute URLs are supported
```

It was caused by URLs of value `null`.

This fix guarantees that only strings can be used for fetching.