### PR TITLE
Add `includeTypes` attribute to support component instance

### DIFF
--- a/packages/cli/src/commands/components.ts
+++ b/packages/cli/src/commands/components.ts
@@ -4,7 +4,7 @@ import { Sade } from 'sade';
 import * as figmaExport from '@figma-export/core';
 import * as FigmaExport from '@figma-export/types';
 
-import { asArray, requirePackages } from '../utils';
+import { asArray, asUndefinableArray, requirePackages } from '../utils';
 
 export const addComponents = (prog: Sade, spinner: Ora) => prog
     .command('components <fileId>')
@@ -15,9 +15,11 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
     .option('-r, --retries', 'Maximum number of retries when fetching fails', 3)
     .option('-o, --output', 'Output directory', 'output')
     .option('-p, --page', 'Figma page names (all pages when not specified)')
+    .option('-t, --types', 'Node types to be exported (COMPONENT or INSTANCE)', 'COMPONENT')
     .option('--fileVersion', `A specific version ID to get. Omitting this will get the current version of the file.
                          https://help.figma.com/hc/en-us/articles/360038006754-View-a-file-s-version-history`)
     .example('components fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-components-as-svg')
+    .example('components fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-components-as-svg -t COMPONENT -t INSTANCE -o dist')
     .action(
         (fileId, {
             fileVersion,
@@ -26,9 +28,12 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
             output,
             ...opts
         }) => {
+            type IncludeTypes = FigmaExport.ComponentsCommandOptions['includeTypes']
+
             const outputter = asArray<string>(opts.outputter);
             const transformer = asArray<string>(opts.transformer);
             const page = asArray<string>(opts.page);
+            const types = asUndefinableArray<string>(opts.types) as IncludeTypes;
 
             spinner.info(`Exporting ${fileId} with [${transformer.join(', ')}] as [${outputter.join(', ')}]`);
 
@@ -41,6 +46,7 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
                 retries,
                 token: process.env.FIGMA_TOKEN || '',
                 onlyFromPages: page,
+                includeTypes: types,
                 transformers: requirePackages<FigmaExport.StringTransformer>(transformer),
                 outputters: requirePackages<FigmaExport.ComponentOutputter>(outputter, { output }),
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -16,6 +16,10 @@ export const requirePackages = <T extends Function>(packages: string[], baseOpti
     });
 };
 
+export function asUndefinableArray<T>(entry: T | T[] | undefined): T[] | undefined {
+    return entry ? ([] as T[]).concat(entry) : undefined;
+}
+
 export function asArray<T>(entry: T | T[] | undefined): T[] {
-    return entry ? ([] as T[]).concat(entry) : [];
+    return asUndefinableArray(entry) ?? [];
 }

--- a/packages/core/src/integration.test.ts
+++ b/packages/core/src/integration.test.ts
@@ -16,12 +16,32 @@ describe('@figma-export/core', () => {
         // console.info(pageNodes);
 
         expect(pageNodes.length).to.eq(1);
-        expect(pageNodes[0].components.length).to.eq(4);
+        expect(pageNodes[0].components.length).to.eq(5);
         expect(pageNodes[0].components.map((c) => c.name)).to.eql([
             'figma default logo',
             'figma/logo',
             'figma/logo/main',
             'figma/logo/main (bright)',
+            'Type=Icon only, Visible=No',
+        ]);
+    }).timeout(60 * 1000);
+
+    it('Export components (only instances)', async () => {
+        const pageNodes = await exportComponents({
+            fileId: 'fzYhvQpqwhZDUImRz431Qo',
+            token: process.env.FIGMA_TOKEN ?? '',
+            onlyFromPages: ['unit-test'],
+            includeTypes: ['INSTANCE'],
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            log: () => {},
+        });
+
+        // console.info(pageNodes);
+
+        expect(pageNodes.length).to.eq(1);
+        expect(pageNodes[0].components.length).to.eq(1);
+        expect(pageNodes[0].components.map((c) => c.name)).to.eql([
+            'figma/logo/main (bright) - INSTANCE',
         ]);
     }).timeout(60 * 1000);
 
@@ -37,6 +57,12 @@ describe('@figma-export/core', () => {
         // console.info(styles);
 
         expect(styles.length).to.eq(1);
-        expect(styles[0].name).to.eq('purple/with/special#characters');
+        expect(styles.map(({ name, comment, visible }) => ({ name, comment, visible }))).to.deep.eq([
+            {
+                comment: 'inside a subfolder\nand newline',
+                name: 'purple/with/special#characters',
+                visible: true,
+            },
+        ]);
     }).timeout(60 * 1000);
 });

--- a/packages/core/src/lib/_config.test.ts
+++ b/packages/core/src/lib/_config.test.ts
@@ -53,6 +53,28 @@ export const componentOutput1: FigmaExport.ComponentNode = {
     },
 };
 
+export const instanceComponent1: Figma.Node = {
+    ...({} as Figma.Instance),
+    id: '10:98',
+    name: 'Figma-Logo (INSTANCE)',
+    type: 'INSTANCE',
+    componentId: '10:8',
+};
+
+export const instanceComponentOutput1: FigmaExport.ComponentNode = {
+    ...instanceComponent1,
+    svg: '',
+    figmaExport: {
+        id: '10:98',
+        dirname: '.',
+        basename: 'Figma-Logo (INSTANCE)',
+        pathToComponent: [
+            { name: 'A Frame', type: 'FRAME' },
+            { name: 'A Group', type: 'GROUP' },
+        ],
+    },
+};
+
 export const component2: Figma.Node = {
     ...({} as Figma.Component),
     id: '8:1',
@@ -97,7 +119,7 @@ export const group1: Figma.Group = {
     id: '26:0',
     name: 'A Group',
     type: 'GROUP',
-    children: [component3],
+    children: [instanceComponent1, component3],
 };
 
 export const page1: Figma.Canvas = {

--- a/packages/core/src/lib/export-components.ts
+++ b/packages/core/src/lib/export-components.ts
@@ -13,6 +13,7 @@ export const components: FigmaExport.ComponentsCommand = async ({
     version,
     onlyFromPages = [],
     filterComponent = () => true,
+    includeTypes = ['COMPONENT'],
     transformers = [],
     outputters = [],
     concurrency = 30,
@@ -34,7 +35,7 @@ export const components: FigmaExport.ComponentsCommand = async ({
         },
     );
 
-    const pages = getPagesWithComponents(figmaDocument, { filterComponent });
+    const pages = getPagesWithComponents(figmaDocument, { filterComponent, includeTypes });
 
     log('preparing components');
     const pagesWithSvg = await enrichPagesWithSvg(client, fileId, pages, version, {

--- a/packages/output-components-as-es6/src/index.test.ts
+++ b/packages/output-components-as-es6/src/index.test.ts
@@ -15,6 +15,11 @@ import fs from 'fs';
 import path from 'path';
 import outputter from './index';
 
+const getComponentsDefaultOptions: Parameters<typeof figma.getComponents>[1] = {
+    filterComponent: () => true,
+    includeTypes: ['COMPONENT'],
+};
+
 describe('outputter as es6', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let clientFileImages: sinon.SinonStub<any[], any>;
@@ -70,7 +75,7 @@ describe('outputter as es6', () => {
     it('should export all components into an es6 file', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document, getComponentsDefaultOptions);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();
@@ -91,7 +96,7 @@ describe('outputter as es6', () => {
     it('should use "variablePrefix" and "variableSuffix" options to prepend or append a text to the variable name', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document, getComponentsDefaultOptions);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();
@@ -113,7 +118,7 @@ describe('outputter as es6', () => {
     it('should export all components into an es6 file using base64 encoding if set', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document, getComponentsDefaultOptions);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();
@@ -134,7 +139,7 @@ describe('outputter as es6', () => {
     it('should export all components into an es6 file using dataUrl if set', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document, getComponentsDefaultOptions);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();
@@ -161,7 +166,7 @@ describe('outputter as es6', () => {
     it('should not break when transformers return "undefined"', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document, getComponentsDefaultOptions);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages, undefined, {
             transformers: [async () => undefined],
         });
@@ -190,7 +195,7 @@ describe('outputter as es6', () => {
         sinon.stub(fs, 'writeFileSync');
 
         const document = figmaDocument.createDocument({ children: [page] });
-        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document, getComponentsDefaultOptions);
         const spyOutputter = sinon.spy(outputter);
 
         return spyOutputter({
@@ -212,7 +217,7 @@ describe('outputter as es6', () => {
         sinon.stub(fs, 'writeFileSync');
 
         const document = figmaDocument.createDocument({ children: [page] });
-        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document, getComponentsDefaultOptions);
         const spyOutputter = sinon.spy(outputter);
 
         return spyOutputter({
@@ -228,7 +233,7 @@ describe('outputter as es6', () => {
     it('should create folders and subfolders when pageName contains slashes', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1WithSlashes] });
-        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document);
+        const pages: FigmaExport.PageNode[] = figma.getPagesWithComponents(document, getComponentsDefaultOptions);
         const pagesWithSvg = await figma.enrichPagesWithSvg(client, 'fileABCD', pages);
 
         nockScope.done();

--- a/packages/output-components-as-stdout/src/index.test.ts
+++ b/packages/output-components-as-stdout/src/index.test.ts
@@ -10,7 +10,10 @@ import outputter = require('./index');
 describe('outputter as stdout', () => {
     it('should output pages in console as json', async () => {
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages = figma.getPagesWithComponents(document);
+        const pages = figma.getPagesWithComponents(document, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
         await outputter()(pages);
         expect(console.log).to.have.been.calledOnce;
         expect(console.log).to.have.been.calledWith(`${JSON.stringify(pages)}`);

--- a/packages/output-components-as-svg/src/index.test.ts
+++ b/packages/output-components-as-svg/src/index.test.ts
@@ -19,7 +19,10 @@ describe('outputter as svg', () => {
     it('should export all components into svg files', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages = figma.getPagesWithComponents(document);
+        const pages = figma.getPagesWithComponents(document, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         await outputter({
             output: 'output',
@@ -33,7 +36,10 @@ describe('outputter as svg', () => {
     it('should create folder if component names contain slashes', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const fakePages = figmaDocument.createPage([figmaDocument.componentWithSlashedName]);
-        const pages = figma.getPagesWithComponents(fakePages);
+        const pages = figma.getPagesWithComponents(fakePages, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         await outputter({
             output: 'output',
@@ -45,7 +51,10 @@ describe('outputter as svg', () => {
 
     describe('options', () => {
         const fakePages = figmaDocument.createPage([figmaDocument.componentWithSlashedName]);
-        const pages = figma.getPagesWithComponents(fakePages);
+        const pages = figma.getPagesWithComponents(fakePages, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         it('should be able to customize "basename"', async () => {
             const writeFileSync = sinon.stub(fs, 'writeFileSync');

--- a/packages/output-components-as-svgr/src/index.test.ts
+++ b/packages/output-components-as-svgr/src/index.test.ts
@@ -56,7 +56,10 @@ describe('outputter as svgr', () => {
 
     it('should export all components into jsx files plus one index.js for each folder', async () => {
         const fakePage = figmaDocument.createPage([figmaDocument.component1, figmaDocument.component2]);
-        const pages = figma.getPagesWithComponents(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         await outputter({
             output: 'output',
@@ -73,7 +76,10 @@ describe('outputter as svgr', () => {
 
     it('should export all components into tsx files plus one index.ts for each folder', async () => {
         const fakePage = figmaDocument.createPage([figmaDocument.component1, figmaDocument.component2]);
-        const pages = figma.getPagesWithComponents(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         await outputter({
             output: 'output',
@@ -91,7 +97,10 @@ describe('outputter as svgr', () => {
 
     it('should create a custom export for every component using the template passed', async () => {
         const fakePage = figmaDocument.createPage([figmaDocument.component2]);
-        const pages = figma.getPagesWithComponents(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         await outputter({
             output: 'output',
@@ -108,7 +117,10 @@ describe('outputter as svgr', () => {
 
     it('should create folder if component names contain slashes', async () => {
         const fakePage = figmaDocument.createPage([figmaDocument.componentWithSlashedName]);
-        const pages = figma.getPagesWithComponents(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         await outputter({
             output: 'output',
@@ -121,7 +133,10 @@ describe('outputter as svgr', () => {
 
     describe('options', () => {
         const fakePage = figmaDocument.createPage([figmaDocument.componentWithSlashedName]);
-        const pages = figma.getPagesWithComponents(fakePage);
+        const pages = figma.getPagesWithComponents(fakePage, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         it('should be able to customize "dirname"', async () => {
             await outputter({

--- a/packages/output-components-as-svgstore/src/index.test.ts
+++ b/packages/output-components-as-svgstore/src/index.test.ts
@@ -23,7 +23,10 @@ describe('outputter as svgstore', () => {
     it('should create an svg with the page name as filename', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1] });
-        const pages = figma.getPagesWithComponents(document);
+        const pages = figma.getPagesWithComponents(document, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         await outputter({
             output: 'output',
@@ -45,7 +48,10 @@ describe('outputter as svgstore', () => {
     it('should create folders and subfolders when pageName contains slashes', async () => {
         const writeFileSync = sinon.stub(fs, 'writeFileSync');
         const document = figmaDocument.createDocument({ children: [figmaDocument.page1WithSlashes] });
-        const pages = figma.getPagesWithComponents(document);
+        const pages = figma.getPagesWithComponents(document, {
+            filterComponent: () => true,
+            includeTypes: ['COMPONENT'],
+        });
 
         await outputter({
             output: 'output',

--- a/packages/types/src/commands.ts
+++ b/packages/types/src/commands.ts
@@ -1,3 +1,4 @@
+import type * as Figma from 'figma-js';
 import {
     StringTransformer,
     ComponentOutputter,
@@ -33,6 +34,9 @@ export type ComponentsCommandOptions = {
 
     /** Filter components to export */
     filterComponent?: ComponentFilter;
+
+    /** Node types to be exported @default ['COMPONENT'] */
+    includeTypes?: [Extract<Figma.NodeType, 'COMPONENT' | 'INSTANCE'>, ...Extract<Figma.NodeType, 'COMPONENT' | 'INSTANCE'>[]];
 
     /** Transformer module name or path */
     transformers?: StringTransformer[];

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -12,7 +12,7 @@ export type ComponentExtras = {
     }[];
 }
 
-export interface ComponentNode extends Figma.Component {
+export type ComponentNode = (Figma.Component | Figma.Instance) & {
     figmaExport: ComponentExtras;
     svg: string;
 }
@@ -32,4 +32,4 @@ export type ComponentOutputterParamOption = {
 
 export type StyleNode = Figma.Style & Figma.Node
 
-export type ComponentFilter = (component: Figma.Component) => boolean
+export type ComponentFilter = (component: Figma.Component | Figma.Instance) => boolean


### PR DESCRIPTION
Refers to #151 

This PR aims to add the ability to include `INSTANCE` components to the export. By default, all `COMPONENT`s are exported, but now you can add the property `includeTypes` to the `.figmaexportrc.js` file:

```js
...

['components', {
    fileId: 'fzYhvQpqwhZDUImRz431Qo',
    onlyFromPages: ['empty-page', 'icons', 'unit-test'],
    includeTypes: ['COMPONENT', 'INSTANCE'],
    ...
}]
```

Exporting via CLI is straightforward:

```sh
figma-export components fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-components-as-svg -t INSTANCE
```