### PR TITLE
Add support to exporting components and styles by node IDs

### DIFF
--- a/.figmaexportrc.example.js
+++ b/.figmaexportrc.example.js
@@ -4,7 +4,7 @@ module.exports = {
         ['styles', {
             fileId: 'fzYhvQpqwhZDUImRz431Qo',
             // version: 'xxx123456', // optional - file's version history is only supported on paid Figma plans
-            // onlyFromPages: ['icons'], // optional - Figma page names (all pages when not specified)
+            // onlyFromPages: ['icons'], // optional - Figma page names or IDs (all pages when not specified)
             outputters: [
                 require('@figma-export/output-styles-as-sass')({
                     output: './output'

--- a/.figmaexportrc.example.local.ts
+++ b/.figmaexportrc.example.local.ts
@@ -20,7 +20,7 @@ import outputComponentsAsSvgstore from './packages/output-components-as-svgstore
 
 const styleOptions: StylesCommandOptions = {
     fileId: 'fzYhvQpqwhZDUImRz431Qo',
-    // onlyFromPages: ['icons'], // optional - Figma page names (all pages when not specified)
+    // onlyFromPages: ['icons'], // optional - Figma page names or IDs (all pages when not specified)
     outputters: [
         outputStylesAsCss({
             output: './output/styles/css'

--- a/.figmaexportrc.example.ts
+++ b/.figmaexportrc.example.ts
@@ -14,7 +14,7 @@ import outputComponentsAsEs6 from '@figma-export/output-components-as-es6';
 const styleOptions: StylesCommandOptions = {
     fileId: 'fzYhvQpqwhZDUImRz431Qo',
     // version: 'xxx123456', // optional - file's version history is only supported on paid Figma plans
-    // onlyFromPages: ['icons'], // optional - Figma page names (all pages when not specified)
+    // onlyFromPages: ['icons'], // optional - Figma page names or IDs (all pages when not specified)
     outputters: [
         outputStylesAsSass({
             output: './output'

--- a/.figmaexportrc.example.ts
+++ b/.figmaexportrc.example.ts
@@ -14,6 +14,7 @@ import outputComponentsAsEs6 from '@figma-export/output-components-as-es6';
 const styleOptions: StylesCommandOptions = {
     fileId: 'fzYhvQpqwhZDUImRz431Qo',
     // version: 'xxx123456', // optional - file's version history is only supported on paid Figma plans
+    // ids: ['138:52'], // optional - Export only specified node IDs (the `onlyFromPages` option is always ignored when set)
     // onlyFromPages: ['icons'], // optional - Figma page names or IDs (all pages when not specified)
     outputters: [
         outputStylesAsSass({
@@ -25,6 +26,7 @@ const styleOptions: StylesCommandOptions = {
 const componentOptions: ComponentsCommandOptions = {
     fileId: 'fzYhvQpqwhZDUImRz431Qo',
     // version: 'xxx123456', // optional - file's version history is only supported on paid Figma plans
+    // ids: ['54:22'], // optional - Export only specified node IDs (the `onlyFromPages` option is always ignored when set)
     onlyFromPages: ['icons'],
     transformers: [
         transformSvgWithSvgo({

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ module.exports = {
         ['styles', {
             fileId: 'fzYhvQpqwhZDUImRz431Qo',
             // version: 'xxx123456', // optional - file's version history is only supported on paid Figma plans
+            // ids: ['138:52'], // optional - Export only specified node IDs (the `onlyFromPages` option is always ignored when set)
             // onlyFromPages: ['icons'], // optional - Figma page names or IDs (all pages when not specified)
             outputters: [
                 require('@figma-export/output-styles-as-sass')({
@@ -187,6 +188,7 @@ module.exports = {
         ['components', {
             fileId: 'fzYhvQpqwhZDUImRz431Qo',
             // version: 'xxx123456', // optional - file's version history is only supported on paid Figma plans
+            // ids: ['54:22'], // optional - Export only specified node IDs (the `onlyFromPages`    option is always ignored when set)
             onlyFromPages: ['icons'],
             // filterComponent: (component) => !/^figma/.test(component.name), // optional
             transformers: [

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ module.exports = {
         ['styles', {
             fileId: 'fzYhvQpqwhZDUImRz431Qo',
             // version: 'xxx123456', // optional - file's version history is only supported on paid Figma plans
-            // onlyFromPages: ['icons'], // optional - Figma page names (all pages when not specified)
+            // onlyFromPages: ['icons'], // optional - Figma page names or IDs (all pages when not specified)
             outputters: [
                 require('@figma-export/output-styles-as-sass')({
                     output: './output/styles'

--- a/packages/cli/src/commands/components.ts
+++ b/packages/cli/src/commands/components.ts
@@ -14,7 +14,7 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
     .option('-c, --concurrency', 'Concurrency when fetching', 30)
     .option('-r, --retries', 'Maximum number of retries when fetching fails', 3)
     .option('-o, --output', 'Output directory', 'output')
-    .option('-p, --page', 'Figma page names (all pages when not specified)')
+    .option('-p, --page', 'Figma page names or IDs (all pages when not specified)')
     .option('-t, --types', 'Node types to be exported (COMPONENT or INSTANCE)', 'COMPONENT')
     .option('--fileVersion', `A specific version ID to get. Omitting this will get the current version of the file.
                          https://help.figma.com/hc/en-us/articles/360038006754-View-a-file-s-version-history`)

--- a/packages/cli/src/commands/components.ts
+++ b/packages/cli/src/commands/components.ts
@@ -14,12 +14,14 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
     .option('-c, --concurrency', 'Concurrency when fetching', 30)
     .option('-r, --retries', 'Maximum number of retries when fetching fails', 3)
     .option('-o, --output', 'Output directory', 'output')
+    .option('-i, --ids', 'Export only these node IDs (`--page` is always ignored when set)')
     .option('-p, --page', 'Figma page names or IDs (all pages when not specified)')
     .option('-t, --types', 'Node types to be exported (COMPONENT or INSTANCE)', 'COMPONENT')
     .option('--fileVersion', `A specific version ID to get. Omitting this will get the current version of the file.
                          https://help.figma.com/hc/en-us/articles/360038006754-View-a-file-s-version-history`)
     .example('components fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-components-as-svg')
     .example('components fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-components-as-svg -t COMPONENT -t INSTANCE -o dist')
+    .example('components fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-components-as-svg -o dist -i 54:22 -i 138:52')
     .action(
         (fileId, {
             fileVersion,
@@ -32,6 +34,7 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
 
             const outputter = asArray<string>(opts.outputter);
             const transformer = asArray<string>(opts.transformer);
+            const ids = asArray<string>(opts.ids);
             const page = asArray<string>(opts.page);
             const types = asUndefinableArray<string>(opts.types) as IncludeTypes;
 
@@ -45,6 +48,7 @@ export const addComponents = (prog: Sade, spinner: Ora) => prog
                 concurrency,
                 retries,
                 token: process.env.FIGMA_TOKEN || '',
+                ids,
                 onlyFromPages: page,
                 includeTypes: types,
                 transformers: requirePackages<FigmaExport.StringTransformer>(transformer),

--- a/packages/cli/src/commands/styles.ts
+++ b/packages/cli/src/commands/styles.ts
@@ -11,7 +11,7 @@ export const addStyles = (prog: Sade, spinner: Ora) => prog
     .describe('Export styles from a Figma file.')
     .option('-O, --outputter', 'Outputter module or path')
     .option('-o, --output', 'Output directory', 'output')
-    .option('-p, --page', 'Figma page names (all pages when not specified)')
+    .option('-p, --page', 'Figma page names or IDs (all pages when not specified)')
     .option('--fileVersion', `A specific version ID to get. Omitting this will get the current version of the file.
                          https://help.figma.com/hc/en-us/articles/360038006754-View-a-file-s-version-history`)
     .example('styles fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-styles-as-css')

--- a/packages/cli/src/commands/styles.ts
+++ b/packages/cli/src/commands/styles.ts
@@ -11,6 +11,7 @@ export const addStyles = (prog: Sade, spinner: Ora) => prog
     .describe('Export styles from a Figma file.')
     .option('-O, --outputter', 'Outputter module or path')
     .option('-o, --output', 'Output directory', 'output')
+    .option('-i, --ids', 'Figma node IDs (`--page` is always ignored when set)')
     .option('-p, --page', 'Figma page names or IDs (all pages when not specified)')
     .option('--fileVersion', `A specific version ID to get. Omitting this will get the current version of the file.
                          https://help.figma.com/hc/en-us/articles/360038006754-View-a-file-s-version-history`)
@@ -22,6 +23,7 @@ export const addStyles = (prog: Sade, spinner: Ora) => prog
             ...opts
         }) => {
             const outputter = asArray<string>(opts.outputter);
+            const ids = asArray<string>(opts.ids);
             const page = asArray<string>(opts.page);
 
             spinner.info(`Exporting ${fileId} as [${outputter.join(', ')}]`);
@@ -32,6 +34,7 @@ export const addStyles = (prog: Sade, spinner: Ora) => prog
                 fileId,
                 version: fileVersion,
                 token: process.env.FIGMA_TOKEN || '',
+                ids,
                 onlyFromPages: page,
                 outputters: requirePackages<FigmaExport.StyleOutputter>(outputter, { output }),
 

--- a/packages/core/src/integration.test.ts
+++ b/packages/core/src/integration.test.ts
@@ -8,7 +8,7 @@ describe('@figma-export/core', () => {
         const pageNodes = await exportComponents({
             fileId: 'fzYhvQpqwhZDUImRz431Qo',
             token: process.env.FIGMA_TOKEN ?? '',
-            onlyFromPages: ['unit-test'],
+            onlyFromPages: ['138:28'],
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             log: () => {},
         });

--- a/packages/core/src/lib/_mocks_/figma.fileNodes.json
+++ b/packages/core/src/lib/_mocks_/figma.fileNodes.json
@@ -1,17 +1,26 @@
 {
-    "name": "Figma Export (Copy)",
-    "lastModified": "2020-10-30T18:56:51.987978Z",
-    "thumbnailUrl": "https://s3-alpha-sig.figma.com/thumbnails/761a94c6-4a19-49dd-bfb2-782b960c3a40?Expires=1604880000&Signature=epETf3LgQuX1XH2lFXGpONnEwnH6vcEmK-VvYOO2i9-~wXE2DxNuf7RCsw6YejiT5eq~UtZS0dsWfJcJfZCs8Xiu~fhSY7mT8RZChxjIC5-MysgPmpRRdCmByW82nvGvNRl9bJBUvqSp5HC3pnAdbjj1FllYQ7dtMZOHJEbFuwKmbRgVWb75TGK8E~O6Ag0vUL7saaSbrm9jlnno00UiXDHUbXBd9MFnNsDEk~Is0hPkjnLtCgjLhXaPOyktCgACotLPgOiABIqP8Lru6ExYbgXFgMHl53nNpXW9Xbb6mGqxM~XSPa38xN4S~9G2N3~eFw0a5jMnJQUPqpQfPMc2Xw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
-    "version": "522617996",
-    "role": "owner",
+    "name": "figma-export",
+    "lastModified": "2024-02-12T15:56:53Z",
+    "thumbnailUrl": "https://s3-alpha.figma.com/thumbnails/902c7922-b242-45d5-ac36-7676cc4b82d3?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ4GOSFWC7BV3ABO4%2F20240211%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20240211T120000Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=e5e440a039dcb97e069a5e08b2ac9a155d4fa4c2dad5ebdcb278addae1a2493a",
+    "version": "5138552565",
+    "role": "viewer",
+    "editorType": "figma",
+    "linkAccess": "view",
     "nodes": {
         "339:0": {
             "document": {
                 "id": "339:0",
                 "name": "color-linear-gradient",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -67,6 +76,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -75,8 +85,15 @@
                 "id": "598:7",
                 "name": "color-figma-gradient",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -161,6 +178,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -169,8 +187,15 @@
                 "id": "339:5",
                 "name": "color-figma-gradient-10",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -212,21 +237,12 @@
                         "gradientStops": [
                             {
                                 "color": {
-                                    "r": 0.9490196108818054,
-                                    "g": 0.30588236451148987,
-                                    "b": 0.11764705926179886,
+                                    "r": 0.03921568766236305,
+                                    "g": 0.8117647171020508,
+                                    "b": 0.5137255191802979,
                                     "a": 1
                                 },
                                 "position": 0
-                            },
-                            {
-                                "color": {
-                                    "r": 0.7212237119674683,
-                                    "g": 0.3490196466445923,
-                                    "b": 1,
-                                    "a": 1
-                                },
-                                "position": 0.34375
                             },
                             {
                                 "color": {
@@ -235,13 +251,22 @@
                                     "b": 0.9960784316062927,
                                     "a": 1
                                 },
-                                "position": 0.6770833134651184
+                                "position": 0.3177083432674408
                             },
                             {
                                 "color": {
-                                    "r": 0.03921568766236305,
-                                    "g": 0.8117647171020508,
-                                    "b": 0.5137255191802979,
+                                    "r": 0.7212237119674683,
+                                    "g": 0.3490196466445923,
+                                    "b": 1,
+                                    "a": 1
+                                },
+                                "position": 0.7083333134651184
+                            },
+                            {
+                                "color": {
+                                    "r": 0.9490196108818054,
+                                    "g": 0.30588236451148987,
+                                    "b": 0.11764705926179886,
                                     "a": 1
                                 },
                                 "position": 1
@@ -255,6 +280,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -263,8 +289,15 @@
                 "id": "121:17",
                 "name": "color-3",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -292,6 +325,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -300,12 +334,19 @@
                 "id": "122:18",
                 "name": "regular-text",
                 "type": "TEXT",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
                     "y": 0,
-                    "width": 0,
-                    "height": 56
+                    "width": 46,
+                    "height": 16
+                },
+                "absoluteRenderBounds": {
+                    "x": 1.080078125,
+                    "y": 2.91015625,
+                    "width": 43.0185546875,
+                    "height": 13.0087890625
                 },
                 "constraints": {
                     "vertical": "TOP",
@@ -316,18 +357,18 @@
                         "blendMode": "NORMAL",
                         "type": "SOLID",
                         "color": {
-                            "r": 0.7686274647712708,
-                            "g": 0.7686274647712708,
-                            "b": 0.7686274647712708,
+                            "r": 0,
+                            "g": 0,
+                            "b": 0,
                             "a": 1
                         }
                     }
                 ],
                 "strokes": [],
-                "strokeWeight": 1,
+                "strokeWeight": 0,
                 "strokeAlign": "INSIDE",
                 "effects": [],
-                "characters": "48px Roboto Regular",
+                "characters": "Rag 123",
                 "style": {
                     "fontFamily": "Roboto Condensed",
                     "fontPostScriptName": "RobotoCondensed-Regular",
@@ -341,10 +382,18 @@
                     "lineHeightPercent": 100,
                     "lineHeightUnit": "INTRINSIC_%"
                 },
+                "layoutVersion": 4,
                 "characterStyleOverrides": [],
-                "styleOverrideTable": {}
+                "styleOverrideTable": {},
+                "lineTypes": [
+                    "NONE"
+                ],
+                "lineIndentations": [
+                    0
+                ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -353,8 +402,15 @@
                 "id": "121:18",
                 "name": "color-4",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -382,6 +438,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -390,12 +447,19 @@
                 "id": "400:33",
                 "name": "deleted-text",
                 "type": "TEXT",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
                     "y": 0,
-                    "width": 0,
-                    "height": 16
+                    "width": 43,
+                    "height": 21
+                },
+                "absoluteRenderBounds": {
+                    "x": 0,
+                    "y": 4.896484375,
+                    "width": 42.5537109375,
+                    "height": 13.015625
                 },
                 "constraints": {
                     "vertical": "TOP",
@@ -406,18 +470,18 @@
                         "blendMode": "NORMAL",
                         "type": "SOLID",
                         "color": {
-                            "r": 0.7686274647712708,
-                            "g": 0.7686274647712708,
-                            "b": 0.7686274647712708,
+                            "r": 0,
+                            "g": 0,
+                            "b": 0,
                             "a": 1
                         }
                     }
                 ],
                 "strokes": [],
-                "strokeWeight": 1,
+                "strokeWeight": 0,
                 "strokeAlign": "INSIDE",
                 "effects": [],
-                "characters": "14px Roboto Condensed Bold",
+                "characters": "Rag 123",
                 "style": {
                     "fontFamily": "Roboto Condensed",
                     "fontPostScriptName": "RobotoCondensed-Bold",
@@ -429,14 +493,23 @@
                     "textAlignHorizontal": "LEFT",
                     "textAlignVertical": "TOP",
                     "letterSpacing": 0,
-                    "lineHeightPx": 16.40625,
-                    "lineHeightPercent": 100,
-                    "lineHeightUnit": "INTRINSIC_%"
+                    "lineHeightPx": 21,
+                    "lineHeightPercent": 128,
+                    "lineHeightPercentFontSize": 150,
+                    "lineHeightUnit": "FONT_SIZE_%"
                 },
+                "layoutVersion": 4,
                 "characterStyleOverrides": [],
-                "styleOverrideTable": {}
+                "styleOverrideTable": {},
+                "lineTypes": [
+                    "NONE"
+                ],
+                "lineIndentations": [
+                    0
+                ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -445,8 +518,15 @@
                 "id": "121:16",
                 "name": "color-2",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -474,6 +554,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -482,6 +563,7 @@
                 "id": "122:16",
                 "name": "h2",
                 "type": "TEXT",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
@@ -489,6 +571,7 @@
                     "width": 0,
                     "height": 75
                 },
+                "absoluteRenderBounds": null,
                 "constraints": {
                     "vertical": "TOP",
                     "horizontal": "LEFT"
@@ -525,9 +608,16 @@
                     "lineHeightUnit": "INTRINSIC_%"
                 },
                 "characterStyleOverrides": [],
-                "styleOverrideTable": {}
+                "styleOverrideTable": {},
+                "lineTypes": [
+                    "NONE"
+                ],
+                "lineIndentations": [
+                    0
+                ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -536,8 +626,15 @@
                 "id": "121:10",
                 "name": "color-1",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -576,6 +673,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -584,6 +682,7 @@
                 "id": "122:14",
                 "name": "h1",
                 "type": "TEXT",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
@@ -591,6 +690,7 @@
                     "width": 0,
                     "height": 75
                 },
+                "absoluteRenderBounds": null,
                 "constraints": {
                     "vertical": "TOP",
                     "horizontal": "LEFT"
@@ -630,9 +730,16 @@
                     "lineHeightUnit": "PIXELS"
                 },
                 "characterStyleOverrides": [],
-                "styleOverrideTable": {}
+                "styleOverrideTable": {},
+                "lineTypes": [
+                    "NONE"
+                ],
+                "lineIndentations": [
+                    0
+                ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -641,12 +748,19 @@
                 "id": "433:8",
                 "name": "multi-shadows",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
                     "height": 100
+                },
+                "absoluteRenderBounds": {
+                    "x": -4,
+                    "y": 0,
+                    "width": 108,
+                    "height": 108
                 },
                 "constraints": {
                     "vertical": "TOP",
@@ -682,7 +796,8 @@
                             "x": 0,
                             "y": 4
                         },
-                        "radius": 4
+                        "radius": 4,
+                        "showShadowBehindNode": true
                     },
                     {
                         "type": "INNER_SHADOW",
@@ -703,6 +818,7 @@
                 ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -711,12 +827,19 @@
                 "id": "376:13",
                 "name": "mixed-effects",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
                     "height": 100
+                },
+                "absoluteRenderBounds": {
+                    "x": -4,
+                    "y": -4,
+                    "width": 108,
+                    "height": 112
                 },
                 "constraints": {
                     "vertical": "TOP",
@@ -757,7 +880,8 @@
                             "x": 0,
                             "y": 4
                         },
-                        "radius": 4
+                        "radius": 4,
+                        "showShadowBehindNode": true
                     },
                     {
                         "type": "INNER_SHADOW",
@@ -778,6 +902,7 @@
                 ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -786,12 +911,19 @@
                 "id": "296:7",
                 "name": "layer-blur",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
                     "height": 100
+                },
+                "absoluteRenderBounds": {
+                    "x": -4,
+                    "y": -4,
+                    "width": 108,
+                    "height": 108
                 },
                 "constraints": {
                     "vertical": "TOP",
@@ -821,6 +953,7 @@
                 ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -829,12 +962,19 @@
                 "id": "124:8",
                 "name": "drop-shadow",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
                     "height": 100
+                },
+                "absoluteRenderBounds": {
+                    "x": -10,
+                    "y": -9,
+                    "width": 126,
+                    "height": 126
                 },
                 "constraints": {
                     "vertical": "TOP",
@@ -871,11 +1011,13 @@
                             "y": 4
                         },
                         "radius": 7,
-                        "spread": 6
+                        "spread": 6,
+                        "showShadowBehindNode": true
                     }
                 ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -884,8 +1026,15 @@
                 "id": "376:15",
                 "name": "inner-shadow-bottom",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -931,6 +1080,7 @@
                 ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -939,8 +1089,15 @@
                 "id": "376:2",
                 "name": "inner-shadow",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -986,6 +1143,7 @@
                 ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -994,8 +1152,15 @@
                 "id": "408:8",
                 "name": "color-multi-gradient",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1099,6 +1264,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1107,8 +1273,15 @@
                 "id": "341:2",
                 "name": "color-linear-gradient-alpha",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1164,6 +1337,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1172,8 +1346,15 @@
                 "id": "336:5",
                 "name": "color-alpha-50",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1202,6 +1383,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1210,8 +1392,15 @@
                 "id": "121:12",
                 "name": "color-1-lighter",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1239,6 +1428,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1249,6 +1439,7 @@
                 "visible": false,
                 "type": "RECTANGLE",
                 "locked": true,
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
                     "x": 0,
@@ -1256,6 +1447,7 @@
                     "width": 100,
                     "height": 100
                 },
+                "absoluteRenderBounds": null,
                 "constraints": {
                     "vertical": "TOP",
                     "horizontal": "LEFT"
@@ -1278,6 +1470,52 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
+            "schemaVersion": 0,
+            "styles": {}
+        },
+        "2009:792": {
+            "document": {
+                "id": "2009:792",
+                "name": "purple/with/special#characters",
+                "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "constraints": {
+                    "vertical": "TOP",
+                    "horizontal": "LEFT"
+                },
+                "fills": [
+                    {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                            "r": 0.6352941393852234,
+                            "g": 0.3490196168422699,
+                            "b": 1,
+                            "a": 1
+                        }
+                    }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "effects": []
+            },
+            "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1286,9 +1524,16 @@
                 "id": "124:18",
                 "name": "grid-12",
                 "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "children": [],
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1352,6 +1597,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1360,8 +1606,15 @@
                 "id": "330:1",
                 "name": "unused-color",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1389,6 +1642,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1397,8 +1651,15 @@
                 "id": "339:1",
                 "name": "color-radial-gradient",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1454,6 +1715,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1462,8 +1724,15 @@
                 "id": "339:2",
                 "name": "color-angular-gradient",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1519,6 +1788,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1527,8 +1797,15 @@
                 "id": "339:3",
                 "name": "color-diamond-gradient",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1584,6 +1861,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1592,8 +1870,15 @@
                 "id": "339:7",
                 "name": "color-image",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1617,6 +1902,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
@@ -1625,8 +1911,15 @@
                 "id": "376:9",
                 "name": "background-blur",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1660,16 +1953,24 @@
                 ]
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         },
-        "626:1": {
+        "630:791": {
             "document": {
-                "id": "626:1",
+                "id": "630:791",
                 "name": "color-figma-gradient-05",
                 "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
                 "blendMode": "PASS_THROUGH",
                 "absoluteBoundingBox": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 100,
+                    "height": 100
+                },
+                "absoluteRenderBounds": {
                     "x": 0,
                     "y": 0,
                     "width": 100,
@@ -1711,21 +2012,12 @@
                         "gradientStops": [
                             {
                                 "color": {
-                                    "r": 0.9490196108818054,
-                                    "g": 0.30588236451148987,
-                                    "b": 0.11764705926179886,
+                                    "r": 0.03921568766236305,
+                                    "g": 0.8117647171020508,
+                                    "b": 0.5137255191802979,
                                     "a": 1
                                 },
                                 "position": 0
-                            },
-                            {
-                                "color": {
-                                    "r": 0.7212237119674683,
-                                    "g": 0.3490196466445923,
-                                    "b": 1,
-                                    "a": 1
-                                },
-                                "position": 0.34375
                             },
                             {
                                 "color": {
@@ -1734,13 +2026,22 @@
                                     "b": 0.9960784316062927,
                                     "a": 1
                                 },
-                                "position": 0.6770833134651184
+                                "position": 0.3177083432674408
                             },
                             {
                                 "color": {
-                                    "r": 0.03921568766236305,
-                                    "g": 0.8117647171020508,
-                                    "b": 0.5137255191802979,
+                                    "r": 0.7212237119674683,
+                                    "g": 0.3490196466445923,
+                                    "b": 1,
+                                    "a": 1
+                                },
+                                "position": 0.7083333134651184
+                            },
+                            {
+                                "color": {
+                                    "r": 0.9490196108818054,
+                                    "g": 0.30588236451148987,
+                                    "b": 0.11764705926179886,
                                     "a": 1
                                 },
                                 "position": 1
@@ -1754,6 +2055,7 @@
                 "effects": []
             },
             "components": {},
+            "componentSets": {},
             "schemaVersion": 0,
             "styles": {}
         }

--- a/packages/core/src/lib/export-components.test.ts
+++ b/packages/core/src/lib/export-components.test.ts
@@ -197,6 +197,27 @@ describe('export-component', () => {
         expect(outputter).to.have.been.calledOnceWithExactly(pagesWithSvg);
     });
 
+    it('should filter by selected IDs when setting "ids" argument', async () => {
+        await exportComponents({
+            fileId: 'fileABCD',
+            version: 'versionABCD',
+            token: 'token1234',
+            log: logger,
+            outputters: [outputter],
+            transformers: [transformer],
+            ids: ['9:1'],
+        });
+
+        nockScope.done();
+
+        expect(FigmaExport.getClient).to.have.been.calledOnceWithExactly('token1234');
+
+        expect(clientFile).to.have.been.calledOnce;
+        expect(clientFile.firstCall).to.have.been.calledWith('fileABCD', {
+            version: 'versionABCD', depth: undefined, ids: ['9:1'],
+        });
+    });
+
     it('should throw an error when onlyFromPages is set to a page not found', async () => {
         // eslint-disable-next-line no-return-await
         await expect(exportComponents({

--- a/packages/core/src/lib/export-components.ts
+++ b/packages/core/src/lib/export-components.ts
@@ -11,6 +11,7 @@ export const components: FigmaExport.ComponentsCommand = async ({
     token,
     fileId,
     version,
+    ids = [],
     onlyFromPages = [],
     filterComponent = () => true,
     includeTypes = ['COMPONENT'],
@@ -31,6 +32,7 @@ export const components: FigmaExport.ComponentsCommand = async ({
         {
             fileId,
             version,
+            ids,
             onlyFromPages,
         },
     );

--- a/packages/core/src/lib/export-styles.ts
+++ b/packages/core/src/lib/export-styles.ts
@@ -7,6 +7,7 @@ export const styles: FigmaExport.StylesCommand = async ({
     token,
     fileId,
     version,
+    ids = [],
     onlyFromPages = [],
     outputters = [],
     log = (msg): void => {
@@ -22,6 +23,7 @@ export const styles: FigmaExport.StylesCommand = async ({
         {
             fileId,
             version,
+            ids,
             onlyFromPages,
         },
     );

--- a/packages/core/src/lib/figmaStyles/index.test.ts
+++ b/packages/core/src/lib/figmaStyles/index.test.ts
@@ -85,7 +85,7 @@ describe('figmaStyles.', () => {
 
             expect(client.fileNodes).to.have.been.calledWith('ABC123', { ids: nodeIds, version: 'version123' });
 
-            const expectedStyleNodesLength = 30;
+            const expectedStyleNodesLength = 31;
             const expectedUnusedLength = 1;
             expect(styleNodes.length).to.equal(expectedStyleNodesLength);
             expect(styleNodes.filter((node) => node.visible === false).map((node) => node.name)).to.deep.equal(['black']);
@@ -221,12 +221,12 @@ describe('figmaStyles.', () => {
                                 visible: true,
                                 angle: '90deg',
                                 gradientStops: [
-                                    { color: { r: 242, g: 78, b: 30, a: 0.1, rgba: 'rgba(242, 78, 30, 0.1)' }, position: 0 },
-                                    { color: { r: 184, g: 89, b: 255, a: 0.1, rgba: 'rgba(184, 89, 255, 0.1)' }, position: 34.375 },
-                                    { color: { r: 26, g: 188, b: 254, a: 0.1, rgba: 'rgba(26, 188, 254, 0.1)' }, position: 67.708 },
-                                    { color: { r: 10, g: 207, b: 131, a: 0.1, rgba: 'rgba(10, 207, 131, 0.1)' }, position: 100 },
+                                    { color: { r: 10, g: 207, b: 131, a: 0.1, rgba: 'rgba(10, 207, 131, 0.1)' }, position: 0 },
+                                    { color: { r: 26, g: 188, b: 254, a: 0.1, rgba: 'rgba(26, 188, 254, 0.1)' }, position: 31.771 },
+                                    { color: { r: 184, g: 89, b: 255, a: 0.1, rgba: 'rgba(184, 89, 255, 0.1)' }, position: 70.833 },
+                                    { color: { r: 242, g: 78, b: 30, a: 0.1, rgba: 'rgba(242, 78, 30, 0.1)' }, position: 100 },
                                 ],
-                                value: 'linear-gradient(90deg, rgba(242, 78, 30, 0.1) 0%, rgba(184, 89, 255, 0.1) 34.375%, rgba(26, 188, 254, 0.1) 67.708%, rgba(10, 207, 131, 0.1) 100%)',
+                                value: 'linear-gradient(90deg, rgba(10, 207, 131, 0.1) 0%, rgba(26, 188, 254, 0.1) 31.771%, rgba(184, 89, 255, 0.1) 70.833%, rgba(242, 78, 30, 0.1) 100%)',
                             },
                             {
                                 type: 'SOLID',
@@ -519,11 +519,7 @@ describe('figmaStyles.', () => {
             });
 
             it('should parse a Text style when lineHeightUnit=FONT_SIZE_%', () => {
-                const node = getNode(styleNodes, 'h1');
-
-                // https://jemgold.github.io/figma-js/interfaces/typestyle.html#lineheightunit
-                // @ts-expect-error: "node" has style for sure
-                node.style.lineHeightUnit = 'FONT_SIZE_%';
+                const node = getNode(styleNodes, 'deleted-text');
 
                 const parsed = figmaStyles.parseStyles([node]);
 
@@ -531,20 +527,20 @@ describe('figmaStyles.', () => {
                     {
                         styleType: 'TEXT',
                         visible: true,
-                        name: 'h1',
-                        comment: 'Page title',
+                        name: 'deleted-text',
+                        comment: '',
                         originalNode: node,
                         style: {
-                            fontFamily: 'Spinnaker',
-                            fontSize: 24,
+                            fontFamily: 'Roboto Condensed',
+                            fontSize: 14,
                             fontStyle: 'normal',
                             fontVariant: 'normal',
-                            fontWeight: 400,
-                            letterSpacing: 2,
-                            lineHeight: '1.25',
+                            fontWeight: 700,
+                            letterSpacing: 0,
+                            lineHeight: '1.5',
                             textAlign: 'left',
-                            textDecoration: 'underline',
-                            textTransform: 'capitalize',
+                            textDecoration: 'line-through',
+                            textTransform: 'lowercase',
                             verticalAlign: 'top',
                         },
                     },

--- a/packages/core/src/lib/utils.test.ts
+++ b/packages/core/src/lib/utils.test.ts
@@ -102,12 +102,12 @@ describe('utils.', () => {
         });
     });
 
-    describe('sanitizeOnlyFromPages', () => {
+    describe('forceArray', () => {
         it('should return a not nullish and not empty string array', () => {
-            expect(utils.sanitizeOnlyFromPages(undefined)).to.deep.equal([]);
-            expect(utils.sanitizeOnlyFromPages([''])).to.deep.equal([]);
-            expect(utils.sanitizeOnlyFromPages(['John'])).to.deep.equal(['John']);
-            expect(utils.sanitizeOnlyFromPages(['John', 'Doe'])).to.deep.equal(['John', 'Doe']);
+            expect(utils.forceArray(undefined)).to.deep.equal([]);
+            expect(utils.forceArray([''])).to.deep.equal([]);
+            expect(utils.forceArray(['John'])).to.deep.equal(['John']);
+            expect(utils.forceArray(['John', 'Doe'])).to.deep.equal(['John', 'Doe']);
         });
     });
 });

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -75,10 +75,9 @@ export type PickOption<T extends FigmaExport.ComponentsCommand | FigmaExport.Sty
     Pick<Parameters<T>[0], K>
 
 /**
- * Sanitize `onlyFromPages` option by converting to a not nullish and not empty string array.
+ * Sanitize an array by converting it to a not nullish and not empty string array.
  */
-export function sanitizeOnlyFromPages(
-    onlyFromPages: PickOption<FigmaExport.ComponentsCommand | FigmaExport.StylesCommand, 'onlyFromPages'>['onlyFromPages'],
-) {
-    return (onlyFromPages ?? []).filter((v) => notNullish(v) && notEmptyString(v));
+export function forceArray(maybeArray: string[] | undefined) {
+    return (maybeArray ?? [])
+        .filter((v) => notNullish(v) && notEmptyString(v));
 }

--- a/packages/types/src/commands.ts
+++ b/packages/types/src/commands.ts
@@ -29,7 +29,10 @@ export type ComponentsCommandOptions = {
      */
     version?: string;
 
-    /** // TODO: add description */
+    /**
+     * Export only specified node IDs.
+     * The `onlyFromPages` option is always ignored when set.
+     */
     ids?: string[];
 
     /** Figma page names or IDs (all pages when not specified) */
@@ -67,7 +70,10 @@ export type StylesCommandOptions = {
      */
     version?: string;
 
-    /** // TODO: add description */
+    /**
+     * Export only specified node IDs.
+     * The `onlyFromPages` option is always ignored when set.
+     */
     ids?: string[];
 
     /** Figma page names or IDs (all pages when not specified) */

--- a/packages/types/src/commands.ts
+++ b/packages/types/src/commands.ts
@@ -29,7 +29,10 @@ export type ComponentsCommandOptions = {
      */
     version?: string;
 
-    /** Figma page names (all pages when not specified) */
+    /** // TODO: add description */
+    ids?: string[];
+
+    /** Figma page names or IDs (all pages when not specified) */
     onlyFromPages?: string[];
 
     /** Filter components to export */
@@ -64,7 +67,10 @@ export type StylesCommandOptions = {
      */
     version?: string;
 
-    /** Figma page names (all pages when not specified) */
+    /** // TODO: add description */
+    ids?: string[];
+
+    /** Figma page names or IDs (all pages when not specified) */
     onlyFromPages?: string[];
 
     /** Outputter module name or path */


### PR DESCRIPTION
Refers to #148 

Add support to exporting components and styles by node IDs.

Now you can directly export Node IDs by specifying the `ids` option. The `onlyFromPages` option is always ignored when set.

```js
module.exports = {

    commands: [

        ['styles', {
            fileId: 'fzYhvQpqwhZDUImRz431Qo',
            ids: ['138:52'], // optional - Export only specified node IDs (the `onlyFromPages` option is always ignored when set)
            outputters: [
                require('@figma-export/output-styles-as-sass')({
                    output: './output/styles'
                })
            ]
        }],

        ['components', {
            fileId: 'fzYhvQpqwhZDUImRz431Qo',
            ids: ['54:22'], // optional - Export only specified node IDs (the `onlyFromPages`    option is always ignored when set)
            outputters: [
                require('@figma-export/output-components-as-svg')({
                    output: './output/components'
                })
            ]
        }]

    ]

};
```

The option is available as `-i` or `--ids` via CLI:

```sh
figma-export components fzYhvQpqwhZDUImRz431Qo -O @figma-export/output-components-as-svg -o dist -i 54:22 -i 138:52
```

----

The `onlyFromPages` option can now accept Node IDs.