### PR TITLE
Add `overrides` for axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
   "engines": {
     "node": ">= 16.14"
   },
+  "overrides": {
+    "axios": "^1.6.7"
+  },
   "resolutions": {
     "axios": "^1.6.7"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,9 @@
         "p-limit": "^3.1.0",
         "p-retry": "^4.6.2"
     },
+    "overrides": {
+        "axios": "^1.6.7"
+    },
     "resolutions": {
         "axios": "^1.6.7"
     },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,6 +29,9 @@
     "dependencies": {
         "figma-js": "~1.16.0"
     },
+    "overrides": {
+        "axios": "^1.6.7"
+    },
     "resolutions": {
         "axios": "^1.6.7"
     }


### PR DESCRIPTION
Added the following to the package.json:

```json
"overrides": {
    "axios": "^1.6.7"
  }
```

> Overrides is used to support selective version overrides using npm, which lets you define custom package versions or ranges inside your dependencies. For yarn, use resolutions instead. See: [https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides)