### PR TITLE
Correctly get DROP_SHADOW spread value

### DIFF
--- a/packages/core/src/lib/figmaStyles/effectStyle.ts
+++ b/packages/core/src/lib/figmaStyles/effectStyle.ts
@@ -20,9 +20,10 @@ const createEffectStyle = (effect: Figma.Effect): FigmaExport.EffectStyle | unde
                     inset,
                     offset: effect.offset,
                     blurRadius: effect.radius,
-                    spreadRadius,
+                    // @ts-expect-error figma-js types are not up-to-date
+                    spreadRadius: effect.spread ?? 0,
 
-                    // eslint-disable-next-line max-len
+                    // @ts-expect-error figma-js types are not up-to-date
                     value: `${inset ? 'inset ' : ''}${effect.offset.x}px ${effect.offset.y}px ${effect.radius}px ${effect.spread ?? 0}px ${color.rgba}`,
                 };
             }

--- a/packages/core/src/lib/figmaStyles/effectStyle.ts
+++ b/packages/core/src/lib/figmaStyles/effectStyle.ts
@@ -10,7 +10,6 @@ const createEffectStyle = (effect: Figma.Effect): FigmaExport.EffectStyle | unde
         case 'INNER_SHADOW':
         case 'DROP_SHADOW': {
             const color = extractColor(effect);
-            const spreadRadius = 0;
             const inset = effect.type === 'INNER_SHADOW';
 
             if (color && effect.offset) {
@@ -24,7 +23,7 @@ const createEffectStyle = (effect: Figma.Effect): FigmaExport.EffectStyle | unde
                     spreadRadius,
 
                     // eslint-disable-next-line max-len
-                    value: `${inset ? 'inset ' : ''}${effect.offset.x}px ${effect.offset.y}px ${effect.radius}px ${spreadRadius}px ${color.rgba}`,
+                    value: `${inset ? 'inset ' : ''}${effect.offset.x}px ${effect.offset.y}px ${effect.radius}px ${effect.spread ?? 0}px ${color.rgba}`,
                 };
             }
 

--- a/packages/core/src/lib/figmaStyles/index.test.ts
+++ b/packages/core/src/lib/figmaStyles/index.test.ts
@@ -322,7 +322,7 @@ describe('figmaStyles.', () => {
                             },
                             inset: true,
                             blurRadius: 10,
-                            spreadRadius: 0,
+                            spreadRadius: 2,
                             color: {
                                 r: 242,
                                 g: 78,
@@ -330,7 +330,7 @@ describe('figmaStyles.', () => {
                                 a: 0.5,
                                 rgba: 'rgba(242, 78, 30, 0.5)',
                             },
-                            value: 'inset 4px 5px 10px 0px rgba(242, 78, 30, 0.5)',
+                            value: 'inset 4px 5px 10px 2px rgba(242, 78, 30, 0.5)',
                         }],
                     },
                 ]);
@@ -357,7 +357,7 @@ describe('figmaStyles.', () => {
                             },
                             inset: true,
                             blurRadius: 10,
-                            spreadRadius: 0,
+                            spreadRadius: 2,
                             color: {
                                 r: 242,
                                 g: 78,
@@ -365,7 +365,7 @@ describe('figmaStyles.', () => {
                                 a: 0.5,
                                 rgba: 'rgba(242, 78, 30, 0.5)',
                             },
-                            value: 'inset 4px 5px 10px 0px rgba(242, 78, 30, 0.5)',
+                            value: 'inset 4px 5px 10px 2px rgba(242, 78, 30, 0.5)',
                         }],
                     },
                 ]);
@@ -392,7 +392,7 @@ describe('figmaStyles.', () => {
                             },
                             inset: false,
                             blurRadius: 7,
-                            spreadRadius: 0,
+                            spreadRadius: 6,
                             color: {
                                 r: 0,
                                 g: 0,
@@ -400,7 +400,7 @@ describe('figmaStyles.', () => {
                                 a: 0.25,
                                 rgba: 'rgba(0, 0, 0, 0.25)',
                             },
-                            value: '3px 4px 7px 0px rgba(0, 0, 0, 0.25)',
+                            value: '3px 4px 7px 6px rgba(0, 0, 0, 0.25)',
                         }],
                     },
                 ]);


### PR DESCRIPTION
I noticed there was a discrepancy with drop-shadows from figma-export compared to how they're shown in Figma's dev mode.

The Figma types used in this project from `figma-js` seem to be outdated. Figma's API returns the "spread" value in the effect when it's of type "DROP_SHADOW". 

You can see it in the API reference when searching for the word "spread" on https://www.figma.com/developers/api.