### PR TITLE
fix: use pathToFileURL for dynamic import on Windows

### DIFF
--- a/packages/cli/src/commands/use-config.ts
+++ b/packages/cli/src/commands/use-config.ts
@@ -3,6 +3,7 @@ import type { Sade } from 'sade';
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import * as figmaExport from '@figma-export/core';
 
@@ -28,7 +29,7 @@ export const addUseConfig = (prog: Sade, spinner: Ora) =>
         );
       }
 
-      import(configPath)
+      import(pathToFileURL(configPath).href)
         .then((m) => m.default as FigmaExportRC)
         .then(({ commands }) => {
           const baseCommandOptions: BaseCommandOptions = {


### PR DESCRIPTION
Refers to https://github.com/marcomontalbano/figma-export/issues/185

Using pathToFileURL to convert the config file path to a file URL before dynamic import.This fixes protocol errors that occur when using import() with Windows file paths.
- Replaced `import(configPath)` with `import(pathToFileURL(configPath).href)`
- Ensured compatibility across Windows, macOS, and Linux.